### PR TITLE
Change authentication to session cookies (First approach)

### DIFF
--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -48,11 +48,13 @@ function adduser (username, password, email, cb) {
     , function (error, data, json, response) {
         // if it worked, then we just created a new user, and all is well.
         // but if we're updating a current record, then it'll 409 first
-        if (error && !this.auth) {
+        if (error && !this.token) {
           // must be trying to re-auth on a new machine.
           // use this info as auth
-          var b = new Buffer(username + ":" + password)
-          this.auth = b.toString("base64")
+          return this.login(username, password, function (er, token){
+            if (er) return cb(er)
+            this.adduser(username, password, email, cb)
+          }.bind(this))
         }
 
         if (!error || !response || response.statusCode !== 409) {

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,0 +1,24 @@
+var qs = require('querystring')
+
+module.exports = login
+
+function login (username, password, cb) {
+  if (!username || !password) 
+    return cb(new Error("Username and Password must be provided"))
+
+  var auth = JSON.stringify({ name: username, password: password})
+
+  this.request("POST", "/_session", auth, 
+    function (er, parsed, data, response) {
+      if (er) return cb.call(this, er)
+      
+      var cookies = response.headers["set-cookie"]
+      if (!cookies || !cookies[0]) 
+        throw new Error("No token sent by the server!")
+
+      var tok = cookies[0]
+      this.token = qs.parse(tok, "; ")
+      cb.call(this, null, qs.parse(tok, "; "))
+      
+    }.bind(this))
+}

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -7,7 +7,7 @@ var path = require("path")
 function publish (data, tarball, readme, cb) {
   if (typeof cb !== "function") cb = readme, readme = ""
 
-  if (!this.email || !this.auth || !this.username) {
+  if (!this.email || !this.token) {
     return cb(new Error("auth and email required for publishing"))
   }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -30,8 +30,10 @@ function regRequest (method, where, what, etag, nofollow, cb_) {
 
   var adduserChange = /^\/?-\/user\/org\.couchdb\.user:([^\/]+)\/-rev/
     , adduserNew = /^\/?-\/user\/org\.couchdb\.user:([^\/]+)/
+    , login = /^\/?_session\/?/
     , authRequired = (what || this.alwaysAuth)
                       && !where.match(adduserNew)
+                      && !where.match(login)
                    || where.match(adduserChange)
                    || method === "DELETE"
 
@@ -58,21 +60,21 @@ function regRequest (method, where, what, etag, nofollow, cb_) {
   }
 
   var remote = url.parse(where)
-    , auth = authRequired && this.auth
 
-  if (authRequired && !auth && this.username && this.password) {
-    var a = this.username + ":" + this.password
-    a = new Buffer(a, "utf8").toString("base64")
-    auth = this.auth = a
-  }
+  if (authRequired && !valid(this.token)) {
+    if (!this.auth) {
+      return cb(new Error(
+        "Cannot insert data into the registry without login/auth"))
+    }
 
-  if (authRequired && !auth) {
-    return cb(new Error(
-      "Cannot insert data into the registry without auth"))
-  }
-
-  if (auth) {
-    remote.auth = new Buffer(auth, "base64").toString("utf8")
+    // TODO remove this and throw exception if there is not support for 
+    // keeping user/password
+    var auth = this.auth.split(":")
+    return this.login(auth[0], auth[1], function (er, token) {
+      if (er) return cb(er)
+      // this.token = token  // <- set by login
+      regRequest.call(this, method, where, what, etag, nofollow, cb_)
+    }.bind(this))
   }
 
   // Tuned to spread 3 attempts over about a minute.
@@ -114,6 +116,11 @@ function makeRequest (method, remote, where, what, etag, nofollow, cb_) {
              , ca: this.ca
              , strictSSL: this.strictSSL }
     , headers = opts.headers = {}
+  
+  if (this.token) {
+    headers.cookie = "AuthSession=" + this.token.AuthSession
+  }
+
   if (etag) {
     this.log.verbose("etag", etag)
     headers[method === "GET" ? "if-none-match" : "if-match"] = etag
@@ -239,4 +246,8 @@ function requestDone (method, where, cb) {
     }
     return cb(er, parsed, data, response)
   }.bind(this)
+}
+
+function valid (token) {
+  return token && token.Expires && Date.parse(token.Expires) > Date.now()
 }

--- a/lib/star.js
+++ b/lib/star.js
@@ -2,7 +2,7 @@
 module.exports = star
 
 function star (package, starred, cb) {
-  if (!this.username) return cb(new Error(
+  if (!this.token) return cb(new Error(
     "Must be logged in to star/unstar packages"))
 
   var users = {}

--- a/test/adduser-update.js
+++ b/test/adduser-update.js
@@ -31,6 +31,21 @@ tap.test("update a user acct", function (t) {
     res.statusCode = 409
     res.json({error: "conflict"})
   })
+  
+  server.expect("POST", "/_session", function (req, res) {
+    t.equal(req.method, "POST")
+    res.statusCode = 200
+    res.setHeader("set-cookie", 
+      ["AuthSession=ZmZsb3Jlczo0RkZCNzVGOTpvDOKn9OWD1zyvMMNy3vagv6FCWQ; " +
+       "Expires=" + new Date((new Date()).getTime() + 60000)])
+    res.json({})
+  })
+  
+  server.expect("PUT", "/-/user/org.couchdb.user:username", function (req, res) {
+    t.equal(req.method, "PUT")
+    res.statusCode = 409
+    res.json({error: "conflict"})
+  })
 
   server.expect("GET", "/-/user/org.couchdb.user:username", function (req, res) {
     t.equal(req.method, "GET")


### PR DESCRIPTION
From [discussion](https://github.com/isaacs/npm-www/issues/15) with Isaac in npm-www:

```
So, we really need to figure out a way to do npm actions on behalf of the logged-in
user. (This will be important for other features in the future as well.)

I think what needs to happen is that the npm-registry-client needs to be able to use
a login token cookie (like couch-login uses) instead of a username/password.
```
### Pull request content:
- client.login method added: return and store a AuthSession token in
  client.token
- Auto login for authRequiered actions if user/password is available
- Update tests
### Examples

```
client.login(username, password, function (er, token) {
  if (er) throw er

  // keep token somewhere for further calls
  save(token)

  client.star(package, true, function (er, data, raw, res) {
    if (er) throw er
    console.log(data)
  })
})
```

Please let me know if you think that it is a wrong approach
