### PR TITLE
Really use _updated flag from server

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -78,7 +78,7 @@ function requestAll_ (c, data, cb) {
   this.request('GET', uri, function (er, updates, _, res) {
     if (er) return cb(er, data)
     var headers = res.headers
-      , updated = data._updated || Date.parse(headers.date)
+      , updated = updates._updated || Date.parse(headers.date)
     Object.keys(updates).forEach(function (p) {
       data[p] = updates[p]
     })


### PR DESCRIPTION
Before this change, npm was pulling everything since the cache was initialized.
Over the past 90 days this has grown to about 3MB.
