### PR TITLE
support SSL client certificates and keys, read from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ also be accepted.
 * `tag` {String} The default tag to use when publishing new packages.
   Default = `"latest"`
 * `ca` {String} Cerficate signing authority certificates to trust.
+* `cert` {String} Path to client certificate for HTTPS requests.
+* `key` {String} Path to client key for HTTPS requests.
 * `strict-ssl` {Boolean} Whether or not to be strict with SSL
   certificates.  Default = `true`
 * `user-agent` {String} User agent header to send.  Default =

--- a/index.js
+++ b/index.js
@@ -62,6 +62,15 @@ function RegClient (conf) {
     this.couchLogin.ca = this.conf.get('ca')
   }
 
+  var keyPath = this.conf.get('key')
+  var certPath = this.conf.get('cert')
+  if(keyPath && certPath){
+    var key = fs.readFileSync(keyPath,'utf8').toString('ascii')
+    var cert = fs.readFileSync(certPath,'utf8').toString('ascii')
+    this.conf.set('key',key)
+    this.conf.set('cert',cert)
+  }
+  
   this.log = conf.log || conf.get('log') || npmlog
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -159,12 +159,19 @@ function makeRequest (method, remote, where, what, etag, nofollow, tok, cb_) {
   }
 
   var strict = this.conf.get('strict-ssl')
+  var key = this.conf.get('key')
+  var cert = this.conf.get('cert')
+
   if (strict === undefined) strict = true
   var opts = { url: remote
              , method: method
              , ca: this.conf.get('ca')
              , strictSSL: strict }
     , headers = opts.headers = {}
+  if(key && cert){
+    opts.key = key
+    opts.cert = cert
+  }
   if (etag) {
     this.log.verbose("etag", etag)
     headers[method === "GET" ? "if-none-match" : "if-match"] = etag

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "request": "~2.9.202",
+    "request": "~2.14.1",
     "graceful-fs": "~1.2.0",
     "semver": "~1.1.0",
     "slide": "~1.1.3",


### PR DESCRIPTION
@isaacs should the key & cert files be read in this module, or somewhere else like `npm` or `npmconf` ?
