### PR TITLE
Fix scope in `publish` error handler

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -85,10 +85,10 @@ function publish (data, tarball, cb) {
 
       var rev = fullData._rev;
       attach.call(this, data.name, tarball, tbName, rev, function (er) {
-        if (er) return handle(er)
+        if (er) return handle.call(this, er)
         this.log.verbose("publish", "attached", [data.name, tarball, tbName])
         this.request("PUT", dataURI, data, function (er) {
-          if (er) return handle(er)
+          if (er) return handle.call(this, er)
           return cb(er)
         }.bind(this))
       }.bind(this))


### PR DESCRIPTION
Fix crash:

```
npm ERR! TypeError: Cannot call method 'error' of undefined
npm ERR!     at handle (/Users/maciej/dev/js/npm/node_modules/npm-registry-client/lib/publish.js:79:18)
npm ERR!     at RegClient.<anonymous> (/Users/maciej/dev/js/npm/node_modules/npm-registry-client/lib/publish.js:88:24)
npm ERR!     at cb (/Users/maciej/dev/js/npm/node_modules/npm-registry-client/lib/request.js:27:9)
npm ERR!     at RegClient.<anonymous> (/Users/maciej/dev/js/npm/node_modules/npm-registry-client/lib/request.js:148:10)
npm ERR!     at cb (/Users/maciej/dev/js/npm/node_modules/npm-registry-client/lib/request.js:158:9)
npm ERR!     at RegClient.<anonymous> (/Users/maciej/dev/js/npm/node_modules/npm-registry-client/lib/request.js:223:20)
npm ERR!     at self.callback (/Users/maciej/dev/js/npm/node_modules/request/main.js:120:22)
npm ERR!     at Request.EventEmitter.emit (events.js:124:20)
npm ERR!     at ClientRequest.self.clientErrorHandler (/Users/maciej/dev/js/npm/node_modules/request/main.js:222:10)
npm ERR!     at ClientRequest.EventEmitter.emit (events.js:94:17)
```
