### PR TITLE
Add a `.deprecate` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ around this. one.
 
 Add a user account to the registry, or verify the credentials.
 
+# client.deprecate(name, version, message, cb)
+
+* `name` {String} The package name
+* `version` {String} Semver version range
+* `message` {String} The message to use as a deprecation warning
+* `cb` {Function}
+
+Deprecate a version of a package in the registry.
+
 # client.get(url, [timeout], [nofollow], [staleOk], cb)
 
 * `url` {String} The url path to fetch

--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -1,0 +1,28 @@
+
+module.exports = deprecate
+
+var semver = require("semver")
+
+function deprecate (name, ver, message, cb) {
+  if (!this.conf.get('username')) {
+    return cb(new Error("Must be logged in to deprecate a package"))
+  }
+
+  if (semver.validRange(ver) === null) {
+    return cb(new Error("invalid version range: "+ver))
+  }
+
+  var users = {}
+
+  this.get(name, function (er, data) {
+    if (er) return cb(er)
+    // filter all the versions that match
+    Object.keys(data.versions).filter(function (v) {
+      return semver.satisfies(v, ver)
+    }).forEach(function (v) {
+      data.versions[v].deprecated = message
+    })
+    // now update the doc on the registry
+    this.request('PUT', data._id, data, cb)
+  }.bind(this))
+}


### PR DESCRIPTION
Implements the functionality in https://github.com/isaacs/npm/blob/master/lib/deprecate.js as an API method.
