### PR TITLE
Fix context in fs.writeFile callback.

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -52,7 +52,7 @@ function requestAll (cb) {
         fs.writeFile(cache, "{}", function (er) {
           if (er) return cb(new Error("Broken cache."))
           return requestAll_.call(this, 0, {}, cb)
-        })
+        }.bind(this))
       }
       var t = +data._updated || 0
       requestAll_.call(this, t, data, cb)


### PR DESCRIPTION
Fixes error:

npm http 200 https://registry.npmjs.org/-/all/since?stale=update_after&startkey=1366973405680
npm WARN Building the local index for the first time, please be patient
npm http GET https://registry.npmjs.org/-/all

/var/www/node_modules/npm/node_modules/npm-registry-client/lib/get.js:73
    this.log.warn("", "Building the local index for the first time, please be
             ^
TypeError: Cannot call method 'warn' of undefined
    at requestAll_ (/var/www/node_modules/npm/node_modules/npm-registry-client/lib/get.js:73:14)
    at /var/www/node_modules/npm/node_modules/npm-registry-client/lib/get.js:54:30
    at Object.oncomplete (fs.js:107:15)
