### PR TITLE
Hide http auth information in npm install log.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -222,7 +222,8 @@ function requestDone (method, where, cb) {
   return function (er, response, data) {
     if (er) return cb(er)
 
-    this.log.http(response.statusCode, url.parse(where).href)
+    var urlObj = url.parse(where);
+    this.log.http(response.statusCode, urlObj.href.replace(urlObj.auth, '***'));
 
     var parsed
 


### PR DESCRIPTION
My team use a private registry which used ldap auth, so npm install will print http auth information to screen, it's very insecure.
