### PR TITLE
Change ':' in cachefolders to '_' on windows

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -29,7 +29,13 @@ function get (uri, timeout, nofollow, staleOk, cb) {
     return requestAll.call(this, cb)
   }
 
-  var cache = path.join(this.conf.get('cache'), uri, ".cache.json")
+  var cacheUri = uri
+  // on windows ":" is not an allowed character in a foldername
+  if (process.platform === "win32") {
+    cacheUri = cacheUri.replace(/:/g, '_')
+  }
+  var cache = path.join(this.conf.get('cache'), cacheUri, ".cache.json")
+
   fs.stat(cache, function (er, stat) {
     if (!er) fs.readFile(cache, function (er, data) {
       try { data = JSON.parse(data) }


### PR DESCRIPTION
Fixes #24
