### PR TITLE
Remove readme parameter from the client.publish API documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,10 @@ Add a user account to the registry, or verify the credentials.
 Fetches data from the registry via a GET request, saving it in
 the cache folder with the ETag.
 
-# client.publish(data, tarball, [readme], cb)
+# client.publish(data, tarball, cb)
 
 * `data` {Object} Package data
 * `tarball` {String | Stream} Filename or stream of the package tarball
-* `readme` {String} Contents of the README markdown file
 * `cb` {Function}
 
 Publish a package to the registry.


### PR DESCRIPTION
When learning how to use the npm-registry-client module for an internal project, I noticed that the code no longer contains a readme parameter for the client.publish API.
