### PR TITLE
userobj should not overwrite data.roles for existing user

### DIFF
--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -87,7 +87,7 @@ function adduser (username, password, email, cb) {
                 return cb(er, data, json, response)
               }
               Object.keys(data).forEach(function (k) {
-                if (!userobj[k]) {
+                if (!userobj[k] || k === 'roles') {
                   userobj[k] = data[k]
                 }
               })


### PR DESCRIPTION
__users/org.couchdb.users:user.roles_ can only be changed by admin users. npm-registry-client currently sets roles to [] per default even if there are roles set. This leads to an access error during _npm login_ for existing users w/ roles.
