### PR TITLE
 express ^2.2.1 using the old semver syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "request": "2 >=2.25.0",
     "graceful-fs": "~2.0.0",
-    "semver": "^2.2.1",
+    "semver": "2 >=2.2.1",
     "slide": "~1.1.3",
     "chownr": "0",
     "mkdirp": "~0.3.3",


### PR DESCRIPTION
this makes it possible to install npm-registry client using an version of npm with semver@1

this change should resolve #27
and also https://github.com/dominictarr/npmd/issues/43
