### PR TITLE
calculate hash of the tarball, not the base64 encoded tarball

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -65,7 +65,7 @@ function putFirst (data, tardata, stat, username, email, cb) {
 
   data._id = data.name+"@"+data.version
   data.dist = data.dist || {}
-  data.dist.shasum = crypto.createHash("sha1").update(tardata).digest("hex")
+  data.dist.shasum = crypto.createHash("sha1").update(tardata, 'base64').digest("hex")
   data.dist.tarball = url.resolve(registry, tbURI)
                          .replace(/^https:\/\//, "http://")
 


### PR DESCRIPTION
the previous version set the incorrect shasum - it hashed the base64 encoded string instead of the hash of the tarball. This causes npm to refuse to install any package published with this version. 
Pass the encoding to the `Hash#update` to calculate the correct hash.

Luckily, when you published `npm@1.3.19` (which uses this version of npm-registry-client, and publishes uninstallable packages) you used this version of npm-registry-client, so you can't actually install that version,
and so there isn't a problem of people publishing modules that you can't install.
