### PR TITLE
Support request gzip content.

### DIFF
--- a/test/request-gzip-content.js
+++ b/test/request-gzip-content.js
@@ -1,0 +1,47 @@
+var zlib = require('zlib')
+var tap = require('tap')
+var server = require('./fixtures/server.js')
+var RC = require('../')
+var pkg = {
+  _id: 'some-package-gzip@1.2.3',
+  name: 'some-package-gzip',
+  version: '1.2.3'
+}
+
+zlib.gzip(JSON.stringify(pkg), function (err, pkgGzip) {
+  var client = new RC({
+      cache: __dirname + '/fixtures/cache'
+    , 'fetch-retries': 1
+    , 'fetch-retry-mintimeout': 10
+    , 'fetch-retry-maxtimeout': 100
+    , registry: 'http://localhost:' + server.port })
+
+  tap.test('request gzip package content', function (t) {
+    server.expect('GET', '/some-package-gzip/1.2.3', function (req, res) {
+      res.statusCode = 200
+      res.setHeader('Content-Encoding', 'gzip');
+      res.setHeader('Content-Type', 'application/json');
+      res.end(pkgGzip)
+    })
+
+    client.get('/some-package-gzip/1.2.3', function (er, data, raw, res) {
+      if (er) throw er
+      t.deepEqual(data, pkg)
+      t.end()
+    })
+  })
+
+  tap.test('request wrong gzip package content', function (t) {
+    server.expect('GET', '/some-package-gzip-error/1.2.3', function (req, res) {
+      res.statusCode = 200
+      res.setHeader('Content-Encoding', 'gzip')
+      res.setHeader('Content-Type', 'application/json')
+      res.end(new Buffer('wrong gzip content'))
+    })
+
+    client.get('/some-package-gzip-error/1.2.3', function (er, data, raw, res) {
+      t.ok(er)
+      t.end()
+    })
+  })
+});


### PR DESCRIPTION
Current CDN almost support auto gzip text base content mirrors.
e.g.: http://registry.qiniudn.com/npm
It can save ~650kb through gzip 700kb json content to 38kb.

![image](https://f.cloud.github.com/assets/156269/2301465/901bddae-a146-11e3-9aae-2f8a0be03d80.png)
