### PR TITLE
public: support `gpg-sign` and `gpg-key` options

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -6,6 +6,8 @@ var path = require("path")
   , semver = require("semver")
   , crypto = require("crypto")
   , fs = require("fs")
+  , spawn = require('child_process').spawn
+  , jsonGpg = require('json-gpg')
 
 function publish (data, tarball, cb) {
   var email = this.conf.get('email')
@@ -77,29 +79,33 @@ function putFirst (data, tardata, stat, username, email, cb) {
     length: stat.size
   };
 
-  this.request("PUT", data.name, root, function (er, parsed, json, res) {
-    var r409 = "must supply latest _rev to update existing package"
-    var r409b = "Document update conflict."
-    var conflict = res && res.statusCode === 409
-    if (parsed && (parsed.reason === r409 || parsed.reason === r409b))
-      conflict = true
-
-    // a 409 is typical here.  GET the data and merge in.
-    if (er && !conflict) {
-      this.log.error("publish", "Failed PUT "
-                    +(res && res.statusCode))
+  maybeSign.call(this, root, function(er, root) {
+    if (er)
       return cb(er)
-    }
+    this.request("PUT", data.name, root, function (er, parsed, json, res) {
+      var r409 = "must supply latest _rev to update existing package"
+      var r409b = "Document update conflict."
+      var conflict = res && res.statusCode === 409
+      if (parsed && (parsed.reason === r409 || parsed.reason === r409b))
+        conflict = true
 
-    if (!er && !conflict)
-      return cb(er, parsed, json, res)
-
-    // let's see what versions are already published.
-    var getUrl = data.name + "?write=true"
-    this.request("GET", getUrl, function (er, current) {
-      if (er)
+      // a 409 is typical here.  GET the data and merge in.
+      if (er && !conflict) {
+        this.log.error("publish", "Failed PUT "
+                      +(res && res.statusCode))
         return cb(er)
-      putNext.call(this, data.version, root, current, cb)
+      }
+
+      if (!er && !conflict)
+        return cb(er, parsed, json, res)
+
+      // let's see what versions are already published.
+      var getUrl = data.name + "?write=true"
+      this.request("GET", getUrl, function (er, current) {
+        if (er)
+          return cb(er)
+        putNext.call(this, data.version, root, current, cb)
+      }.bind(this))
     }.bind(this))
   }.bind(this))
 }
@@ -141,10 +147,29 @@ function putNext(newVersion, root, current, cb) {
         current[i] = root[i]
     }
   }
+
   var maint = JSON.parse(JSON.stringify(root.maintainers))
   root.versions[newVersion].maintainers = maint
 
-  this.request("PUT", root.name, current, cb)
+  maybeSign.call(this, current, function(er, current) {
+    if (er)
+      return cb(er)
+    this.request("PUT", root.name, current, cb)
+  }.bind(this))
+}
+
+function maybeSign (current, cb) {
+  delete current.gpg
+  if (!this.conf.get('gpg-sign'))
+    return cb(null, current)
+
+  var signKey = this.conf.get('gpg-key')
+  jsonGpg.sign(current, signKey, function (er, signature) {
+    if (er)
+      return cb(er)
+    current.gpg = signature
+    cb(null, current)
+  }.bind(this))
 }
 
 function conflictError (pkgid, version) {

--- a/package.json
+++ b/package.json
@@ -11,14 +11,15 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "request": "2 >=2.25.0",
-    "graceful-fs": "~2.0.0",
-    "semver": "^2.2.1",
-    "slide": "~1.1.3",
     "chownr": "0",
+    "graceful-fs": "~2.0.0",
+    "json-gpg": "^0.3.0",
     "mkdirp": "~0.3.3",
+    "request": "2 >=2.25.0",
+    "retry": "0.6.0",
     "rimraf": "~2",
-    "retry": "0.6.0"
+    "semver": "^2.2.1",
+    "slide": "~1.1.3"
   },
   "devDependencies": {
     "tap": ""


### PR DESCRIPTION
This is a WIP for adding signatures to the npm packages. Fully enabling it will require server changes too.

Let's discuss the approach here:

* Does GPG seems a good idea for you?
* How will that work on server-side? Will server store all user's public keys and be a PGP endpoint by itself?
  Or should users upload their public keys to their accounts manually with `npm`?

I did not do much, so hopefully you won't be biased to this because of me implementing part of it without approaching consensus. This is mostly a proof of concept.