### PR TITLE
Better error message when auth is required

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -74,7 +74,7 @@ function regRequest (method, where, what, etag, nofollow, cb_) {
 
   if (authRequired && !auth) {
     return cb(new Error(
-      "Cannot insert data into the registry without auth"))
+      "This request requires auth credentials. Run `npm login` and repeat the request."))
   }
 
   if (auth && authRequired) {


### PR DESCRIPTION
Improve the error message returned when the request requires
authentication but credentials were not provided.

The new message includes instructions how to fix the problem
(i.e. run `npm login`).
