### PR TITLE
Prevent unnecessary quotes in fetch log uris.

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -26,7 +26,8 @@ function fetch (uri, headers, cb) {
       })
 
       req.on("response", function (res) {
-        client.log.http("fetch", res.statusCode, uri)
+        // stringify statuscode or logged uri appears in unnecessary 'quotes'
+        client.log.http("fetch", String(res.statusCode), uri)
 
         // Only retry on 408, 5xx or no `response`.
         var statusCode = res && res.statusCode


### PR DESCRIPTION
Currently log output gets distracting quotes around http status responses:
![npm http fetch 200 'https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz'
npm http fetch 200 'https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz'
npm http fetch 200 'https://registry.npmjs.org/connect/-/connect-2.12.0.tgz'
npm http fetch 200 'https://registry.npmjs.org/buster-format/-/buster-format-0.5.6.tgz'
npm http fetch 200 'https://registry.npmjs.org/bignum/-/bignum-0.6.2.tgz'
npm http fetch GET https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.1.2.tgz
npm http request GET https://registry.npmjs.org/json3
npm http fetch GET http://github.com/component/emitter/archive/1.0.1.tar.gz
npm http request GET https://registry.npmjs.org/buster-core
npm http fetch 200 'https://registry.npmjs.org/jssha/-/jssha-1.5.0.tgz'
npm http fetch 200 'https://registry.npmjs.org/browserify/-/browserify-3.40.0.tgz'](https://cloud.githubusercontent.com/assets/43438/3860146/2c01f3b8-1f21-11e4-8dd4-cd9c9b167fc3.png)
#### Why

Second argument is passed as first argument to `util.format`.
Subsequent arguments get quoted if the first argument is non-string:

``` js
node
> util.format(200, 'message')
'200 \'message\''
> // vs
> util.format('200', 'message')
'200 message'
```

This patch ensures the status-code is converted to a string to prevent
this silly behaviour.
