### PR TITLE
Handle % signs in auth properly when followed by numbers

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -109,7 +109,11 @@ function regRequest (method, uri, options, cb_) {
   }
 
   if (auth && authRequired) {
-    remote.auth = new Buffer(auth, "base64").toString("utf8")
+    // Escape any weird characters that might be in the auth string
+    // TODO(isaacs) Clean up this awful back and forth mess.
+    var remoteAuth = new Buffer(auth, "base64").toString("utf8")
+    remoteAuth = encodeURIComponent(remoteAuth).replace(/%3A/, ":")
+    remote.auth = remoteAuth
   }
 
   // Tuned to spread 3 attempts over about a minute.

--- a/test/adduser-new.js
+++ b/test/adduser-new.js
@@ -4,7 +4,7 @@ var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient()
 
-var password = "password"
+var password = "%1234@asdf%"
 , username = "username"
 , email = "i@izs.me"
 , userdata = {

--- a/test/adduser-update.js
+++ b/test/adduser-update.js
@@ -4,7 +4,7 @@ var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient()
 
-var password = "password"
+var password = "%1234@asdf%"
 , username = "username"
 , email = "i@izs.me"
 , userdata = {

--- a/test/bugs.js
+++ b/test/bugs.js
@@ -4,9 +4,9 @@ var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient({
   username      : "username",
-  password      : "password",
+  password      : "%1234@asdf%",
   email         : "ogd@aoaioxxysz.net",
-  _auth         : new Buffer("username  : password").toString("base64"),
+  _auth         : new Buffer("username:%1234@asdf%").toString("base64"),
   "always-auth" : true
 })
 

--- a/test/deprecate.js
+++ b/test/deprecate.js
@@ -6,7 +6,7 @@ var client = common.freshClient({
   username      : "username",
   password      : "password",
   email         : "ogd@aoaioxxysz.net",
-  _auth         : new Buffer("username  : password").toString("base64"),
+  _auth         : new Buffer("username:%1234@asdf%").toString("base64"),
   "always-auth" : true
 })
 

--- a/test/lib/server.js
+++ b/test/lib/server.js
@@ -3,6 +3,7 @@
 var http = require('http')
 var server = http.createServer(handler)
 var port = server.port = process.env.PORT || 1337
+var assert = require("assert")
 server.listen(port)
 
 module.exports = server
@@ -11,6 +12,13 @@ server._expect = {}
 
 function handler (req, res) {
   req.connection.setTimeout(1000)
+
+  // If we got authorization, make sure it's the right password.
+  if (req.headers.authorization) {
+    var auth = req.headers.authorization.replace(/^Basic /, "")
+    auth = new Buffer(auth, "base64").toString("utf8")
+    assert.equal(auth, "username:%1234@asdf%")
+  }
 
   var u = '* ' + req.url
   , mu = req.method + ' ' + req.url

--- a/test/publish-again.js
+++ b/test/publish-again.js
@@ -5,9 +5,9 @@ var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient({
   username: "username",
-  password: "password",
+  password: "%1234@asdf%",
   email: "i@izs.me",
-  _auth: new Buffer("username:password").toString("base64"),
+  _auth: new Buffer("username:%1234@asdf%").toString("base64"),
   "always-auth": true
 })
 

--- a/test/publish.js
+++ b/test/publish.js
@@ -6,9 +6,9 @@ var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient({
   username: "username",
-  password: "password",
+  password: "%1234@asdf%",
   email: "i@izs.me",
-  _auth: new Buffer("username:password").toString("base64"),
+  _auth: new Buffer("username:%1234@asdf%").toString("base64"),
   "always-auth": true
 })
 

--- a/test/star.js
+++ b/test/star.js
@@ -3,16 +3,16 @@ var tap = require("tap")
 var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient({
-  username      : "othiym23",
-  password      : "password",
+  username      : "username",
+  password      : "%1234@asdf%",
   email         : "ogd@aoaioxxysz.net",
-  _auth         : new Buffer("username  : password").toString("base64"),
+  _auth         : new Buffer("username:%1234@asdf%").toString("base64"),
   "always-auth" : true
 })
 
 var cache = require("./fixtures/underscore/cache.json")
 
-var DEP_USER = "othiym23"
+var DEP_USER = "username"
 
 tap.test("star a package", function (t) {
   server.expect("GET", "/underscore?write=true", function (req, res) {

--- a/test/stars.js
+++ b/test/stars.js
@@ -4,9 +4,9 @@ var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient({
   username      : "username",
-  password      : "password",
+  password      : "%1234@asdf%",
   email         : "ogd@aoaioxxysz.net",
-  _auth         : new Buffer("username  : password").toString("base64"),
+  _auth         : new Buffer("username:%1234@asdf%").toString("base64"),
   "always-auth" : true
 })
 

--- a/test/tag.js
+++ b/test/tag.js
@@ -4,9 +4,9 @@ var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient({
   username      : "username",
-  password      : "password",
+  password      : "%1234@asdf%",
   email         : "ogd@aoaioxxysz.net",
-  _auth         : new Buffer("username  : password").toString("base64"),
+  _auth         : new Buffer("username:%1234@asdf%").toString("base64"),
   "always-auth" : true
 })
 

--- a/test/unpublish.js
+++ b/test/unpublish.js
@@ -3,10 +3,10 @@ var tap = require("tap")
 var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient({
-  username      : "othiym23",
-  password      : "password",
+  username      : "username",
+  password      : "%1234@asdf%",
   email         : "ogd@aoaioxxysz.net",
-  _auth         : new Buffer("username  : password").toString("base64"),
+  _auth         : new Buffer("username:%1234@asdf%").toString("base64"),
   "always-auth" : true
 })
 

--- a/test/upload.js
+++ b/test/upload.js
@@ -8,10 +8,10 @@ var server = require("./lib/server.js")
 var cache = require("./fixtures/underscore/cache.json")
 
 var client = common.freshClient({
-  username      : "othiym23",
-  password      : "password",
+  username      : "username",
+  password      : "%1234@asdf%",
   email         : "ogd@aoaioxxysz.net",
-  _auth         : new Buffer("username  : password").toString("base64"),
+  _auth         : new Buffer("username:%1234@asdf%").toString("base64"),
   "always-auth" : true
 })
 


### PR DESCRIPTION
A password like '%1234' would be broken and interpreted as '\u000034' in
the request, becuase it is interpreting the %12 as a percent-encoded
hex, and then it gets broken in the conversion to UTF-8.

Fix npm/npm#6008
Fix npm/npm#5729
Fix npm/npm#5772
Fix npm/npm#5682

Related to npm/npm#5782, but not a fix, since that issue is asking for
the npm client and website to have the _same_ set of rules, and this
commit does not guarantee that that is the case.
