### PR TITLE
Handle % signs in auth properly when followed by numbers

### DIFF
--- a/lib/authify.js
+++ b/lib/authify.js
@@ -14,7 +14,9 @@ function authify (authed, parsed, headers) {
 
   if (authed) {
     if (c && c.username && c.password) {
-      parsed.auth = c.username + ":" + c.password
+      var username = encodeURIComponent(c.username)
+      var password = encodeURIComponent(c.password)
+      parsed.auth = username + ":" + password
     }
     else {
       return new Error(

--- a/test/adduser-new.js
+++ b/test/adduser-new.js
@@ -4,7 +4,7 @@ var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient()
 
-var password = "password"
+var password = "%1234@asdf%"
 , username = "username"
 , email = "i@izs.me"
 , userdata = {

--- a/test/adduser-update.js
+++ b/test/adduser-update.js
@@ -4,7 +4,7 @@ var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 var client = common.freshClient()
 
-var password = "password"
+var password = "%1234@asdf%"
 , username = "username"
 , email = "i@izs.me"
 , userdata = {

--- a/test/lib/server.js
+++ b/test/lib/server.js
@@ -3,6 +3,7 @@
 var http = require('http')
 var server = http.createServer(handler)
 var port = server.port = process.env.PORT || 1337
+var assert = require("assert")
 server.listen(port)
 
 module.exports = server
@@ -11,6 +12,13 @@ server._expect = {}
 
 function handler (req, res) {
   req.connection.setTimeout(1000)
+
+  // If we got authorization, make sure it's the right password.
+  if (req.headers.authorization && req.headers.authorization.match(/^Basic/)) {
+    var auth = req.headers.authorization.replace(/^Basic /, "")
+    auth = new Buffer(auth, "base64").toString("utf8")
+    assert.equal(auth, "username:%1234@asdf%")
+  }
 
   var u = '* ' + req.url
   , mu = req.method + ' ' + req.url

--- a/test/publish-again-scoped.js
+++ b/test/publish-again-scoped.js
@@ -8,7 +8,7 @@ var nerfed = "//localhost:" + server.port + "/:"
 
 var configuration = {}
 configuration[nerfed + "username"]  = "username"
-configuration[nerfed + "_password"] = new Buffer("password").toString("base64")
+configuration[nerfed + "_password"] = new Buffer("%1234@asdf%").toString("base64")
 configuration[nerfed + "email"]     = "i@izs.me"
 
 var client = common.freshClient(configuration)

--- a/test/publish-again.js
+++ b/test/publish-again.js
@@ -8,7 +8,7 @@ var nerfed = "//localhost:" + server.port + "/:"
 
 var configuration = {}
 configuration[nerfed + "username"]  = "username"
-configuration[nerfed + "_password"] = new Buffer("password").toString("base64")
+configuration[nerfed + "_password"] = new Buffer("%1234@asdf%").toString("base64")
 configuration[nerfed + "email"]     = "i@izs.me"
 
 var client = common.freshClient(configuration)

--- a/test/publish-scoped.js
+++ b/test/publish-scoped.js
@@ -9,12 +9,12 @@ var nerfed = "//localhost:" + server.port + "/:"
 
 var configuration = {}
 configuration[nerfed + "username"]  = "username"
-configuration[nerfed + "_password"] = new Buffer("password").toString("base64")
+configuration[nerfed + "_password"] = new Buffer("%1234@asdf%").toString("base64")
 configuration[nerfed + "email"]     = "ogd@aoaioxxysz.net"
 
 var client = common.freshClient(configuration)
 
-var _auth = new Buffer("username:password").toString("base64")
+var _auth = new Buffer("username:%1234@asdf%").toString("base64")
 
 tap.test("publish", function (t) {
   // not really a tarball, but doesn't matter

--- a/test/publish.js
+++ b/test/publish.js
@@ -9,7 +9,7 @@ var nerfed = "//localhost:" + server.port + "/:"
 
 var configuration = {}
 configuration[nerfed + "username"]  = "username"
-configuration[nerfed + "_password"] = new Buffer("password").toString("base64")
+configuration[nerfed + "_password"] = new Buffer("%1234@asdf%").toString("base64")
 configuration[nerfed + "email"]     = "i@izs.me"
 
 var client = common.freshClient(configuration)

--- a/test/star.js
+++ b/test/star.js
@@ -3,13 +3,13 @@ var tap = require("tap")
 var server = require("./lib/server.js")
 var common = require("./lib/common.js")
 
-var DEP_USER = "othiym23"
+var DEP_USER = "username"
 
 var nerfed = "//localhost:" + server.port + "/:"
 
 var configuration = {}
 configuration[nerfed + "username"]  = DEP_USER
-configuration[nerfed + "_password"] = new Buffer("password").toString("base64")
+configuration[nerfed + "_password"] = new Buffer("%1234@asdf%").toString("base64")
 configuration[nerfed + "email"]     = "i@izs.me"
 
 var client = common.freshClient(configuration)

--- a/test/tag.js
+++ b/test/tag.js
@@ -7,7 +7,7 @@ var nerfed = "//localhost:" + server.port + "/:"
 
 var configuration = {}
 configuration[nerfed + "username"]  = "username"
-configuration[nerfed + "_password"] = new Buffer("password").toString("base64")
+configuration[nerfed + "_password"] = new Buffer("%1234@asdf%").toString("base64")
 configuration[nerfed + "email"]     = "i@izs.me"
 
 var client = common.freshClient(configuration)


### PR DESCRIPTION
A password like '%1234' would be broken and interpreted as '\u000034' in
the request, becuase it is interpreting the %12 as a percent-encoded
hex, and then it gets broken in the conversion to UTF-8.

Fix npm/npm#6008
Fix npm/npm#5729
Fix npm/npm#5772
Fix npm/npm#5682

Related to npm/npm#5782, but not a fix, since that issue is asking for
the npm client and website to have the _same_ set of rules, and this
commit does not guarantee that that is the case.

Forward-ported from the fix on the v2.0 branch: 62f04f00983405afb79c249b574d0da376ac5d7d
