### PR TITLE
Not fail if OpenSSL crypto support isn't available

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,9 +1,14 @@
 
 module.exports = publish
 
+var crypto;
+try {
+  crypto = require("crypto")
+}
+catch (er) {}
+
 var url = require("url")
   , semver = require("semver")
-  , crypto = require("crypto")
   , fs = require("fs")
   , fixNameField = require("normalize-package-data/lib/fixer.js").fixNameField
 
@@ -12,6 +17,9 @@ function escaped(name) {
 }
 
 function publish (uri, data, tarball, cb) {
+  if(crypto === undefined)
+    return cb(new Error('node.js compiled with openssl crypto support required for publishing'))
+
   var c = this.conf.getCredentialsByURI(uri)
   if (!(c.token || (c.auth && c.username && c.email))) {
     var er = new Error("auth and email required for publishing")


### PR DESCRIPTION
If node.js is compiled without OpenSSL crypto support NPM fails to load, but it's only required for publishing. This patch catch the exception thrown by 'crypto' module if OpenSSL is not available and left the 'crypto' namespace undefined. Later, when publish() function is called, an error is given on the callback. This way, `npm-registry-client`` and`npm``` itself can be used on node.js compilations without OpenSSL support.
