### PR TITLE
use always-auth from credentials instead of config

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -69,7 +69,11 @@ function makeRequest (remote, headers, cb) {
   var parsed = url.parse(remote)
   this.log.http("fetch", "GET", parsed.href)
 
-  var er = this.authify(this.conf.get("always-auth"), parsed, headers)
+  var er = this.authify(
+    this.conf.getCredentialsByURI(remote).alwaysAuth,
+    parsed,
+    headers
+  )
   if (er) return cb(er)
 
   var opts = this.initialize(

--- a/lib/request.js
+++ b/lib/request.js
@@ -44,7 +44,8 @@ function regRequest (method, uri, options, cb_) {
     , isUserChange = where.match(adduserChange)
     , adduserNew = /^\/?-\/user\/org\.couchdb\.user:([^\/]+)$/
     , isNewUser = where.match(adduserNew)
-    , alwaysAuth = this.conf.get("always-auth")
+    , registry = url.format(parsed)
+    , alwaysAuth = this.conf.getCredentialsByURI(registry).alwaysAuth
     , isDelete = method === "DELETE"
     , isWrite = what || isDelete
 
@@ -70,9 +71,7 @@ function regRequest (method, uri, options, cb_) {
     }).join("/")
     if (q) where += "?" + q
 
-    var registry = url.format(parsed)
     this.log.verbose("request", "resolving registry", [registry, where])
-
     where = url.resolve(registry, where)
     this.log.verbose("request", "after pass 2, where is", where)
   }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,14 @@
   },
   "devDependencies": {
     "concat-stream": "^1.4.6",
+    "npmconf": "^2.1.0",
     "tap": ""
   },
   "optionalDependencies": {
     "npmlog": ""
+  },
+  "peerDependencies": {
+    "npmconf": "^2.1.0"
   },
   "license": "ISC"
 }

--- a/test/fetch-authed.js
+++ b/test/fetch-authed.js
@@ -1,0 +1,56 @@
+var resolve = require("path").resolve
+var createReadStream = require("graceful-fs").createReadStream
+var readFileSync = require("graceful-fs").readFileSync
+
+var tap = require("tap")
+var cat = require("concat-stream")
+
+var server = require("./lib/server.js")
+var common = require("./lib/common.js")
+
+var tgz = resolve(__dirname, "./fixtures/underscore/1.3.3/package.tgz")
+
+tap.test("basic fetch with scoped always-auth enabled", function (t) {
+  server.expect("/underscore/-/underscore-1.3.3.tgz", function (req, res) {
+    t.equal(req.method, "GET", "got expected method")
+    t.equal(
+      req.headers.authorization,
+      "Basic dXNlcm5hbWU6JTEyMzRAYXNkZiU=",
+      "got expected auth header"
+    )
+
+    res.writeHead(200, {
+      "content-type"     : "application/x-tar",
+      "content-encoding" : "gzip"
+    })
+
+    createReadStream(tgz).pipe(res)
+  })
+
+  var nerfed = "//localhost:" + server.port + "/:"
+  var configuration = {}
+  configuration[nerfed + "username"]    = "username"
+  configuration[nerfed + "_password"]   = new Buffer("%1234@asdf%").toString("base64")
+  configuration[nerfed + "email"]       = "i@izs.me"
+  configuration[nerfed + "always-auth"] = true
+
+  var client = common.freshClient(configuration)
+  client.fetch(
+    "http://localhost:1337/underscore/-/underscore-1.3.3.tgz",
+    null,
+    function (er, res) {
+      t.ifError(er, "loaded successfully")
+
+      var sink = cat(function (data) {
+        t.deepEqual(data, readFileSync(tgz))
+        t.end()
+      })
+
+      res.on("error", function (error) {
+        t.ifError(error, "no errors on stream")
+      })
+
+      res.pipe(sink)
+    }
+  )
+})

--- a/test/fetch-not-authed.js
+++ b/test/fetch-not-authed.js
@@ -1,0 +1,52 @@
+var resolve = require("path").resolve
+var createReadStream = require("graceful-fs").createReadStream
+var readFileSync = require("graceful-fs").readFileSync
+
+var tap = require("tap")
+var cat = require("concat-stream")
+
+var server = require("./lib/server.js")
+var common = require("./lib/common.js")
+
+var tgz = resolve(__dirname, "./fixtures/underscore/1.3.3/package.tgz")
+
+tap.test("basic fetch with scoped always-auth disabled", function (t) {
+  server.expect("/underscore/-/underscore-1.3.3.tgz", function (req, res) {
+    t.equal(req.method, "GET", "got expected method")
+    t.notOk(req.headers.authorization, "received no auth header")
+
+    res.writeHead(200, {
+      "content-type"     : "application/x-tar",
+      "content-encoding" : "gzip"
+    })
+
+    createReadStream(tgz).pipe(res)
+  })
+
+  var nerfed = "//localhost:" + server.port + "/:"
+  var configuration = {}
+  configuration[nerfed + "username"]    = "username"
+  configuration[nerfed + "_password"]   = new Buffer("%1234@asdf%").toString("base64")
+  configuration[nerfed + "email"]       = "i@izs.me"
+  configuration[nerfed + "always-auth"] = false
+
+  var client = common.freshClient(configuration)
+  client.fetch(
+    "http://localhost:1337/underscore/-/underscore-1.3.3.tgz",
+    null,
+    function (er, res) {
+      t.ifError(er, "loaded successfully")
+
+      var sink = cat(function (data) {
+        t.deepEqual(data, readFileSync(tgz))
+        t.end()
+      })
+
+      res.on("error", function (error) {
+        t.ifError(error, "no errors on stream")
+      })
+
+      res.pipe(sink)
+    }
+  )
+})

--- a/test/lib/common.js
+++ b/test/lib/common.js
@@ -39,6 +39,10 @@ module.exports = {
           c.email = this.get(nerfed + ":email")
         }
 
+        if (this.get(nerfed + ":always-auth") !== undefined) {
+          c.alwaysAuth = this.get(nerfed + ":always-auth")
+        }
+
         if (c.username && c.password) {
           c.auth = new Buffer(c.username + ":" + c.password).toString("base64")
         }


### PR DESCRIPTION
This depends on new behavior in npmconf! This is a hidden dependency between `npm-registry-client` and `npmconf` that evades semver! It makes me _very uncomfortable!_
