### PR TITLE
Add noproxy configuration.

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -16,6 +16,15 @@ function initialize (uri, method, accept, headers) {
   var p = this.conf.get("proxy")
   var sp = this.conf.get("https-proxy") || p
 
+  var noproxy = this.conf.get("noproxy") ?
+    this.conf.get("noproxy").replace(/\s/g, "").split(",") : []
+
+  if(noproxy.indexOf(uri.hostname) != -1
+    || noproxy.indexOf("." + uri.hostname) != -1) {
+    p = null
+    sp = null
+  }
+
   var opts = {
     url          : uri,
     method       : method,

--- a/test/lib/proxy.js
+++ b/test/lib/proxy.js
@@ -1,0 +1,25 @@
+var http = require('http')
+var request = require('request')
+var proxy = http.createServer(handler)
+proxy.listen(8080)
+
+module.exports = proxy
+
+function handler (req, res) {
+  req.connection.setTimeout(1000)
+  res.statusCode = 200
+
+  this.log.info('proxy', 'Received request for: ' + req.url)
+
+  var serverPort = process.env.PORT || 1337
+  var url = 'http://localhost:' + serverPort + '/proxy-package-gzip/1.2.3'
+  var x = request(url)
+  req.pipe(x)
+  x.pipe(res)
+
+  proxy.close();
+}
+
+// this log is meanto to be overridden
+proxy.log = require("npmlog")
+

--- a/test/noproxy-request-gzip-content.js
+++ b/test/noproxy-request-gzip-content.js
@@ -1,0 +1,44 @@
+var assert = require("assert")
+var zlib = require("zlib")
+var tap = require("tap")
+
+//Should not need to start a proxy.
+var server = require("./lib/server.js")
+var common = require("./lib/common.js")
+var config = {
+  proxy: 'http://localhost:8080',
+  noproxy: 'localhost, .npmjs.org'
+}
+var client = common.freshClient(config)
+
+var TEST_URL = "http://localhost:1337/test-package-gzip/1.2.3"
+
+var pkg = {
+  _id: "test-package-gzip@1.2.3",
+  name: "test-package-gzip",
+  version: "1.2.3"
+}
+
+zlib.gzip(JSON.stringify(pkg), function (err, pkgGzip) {
+  tap.test("request gzip package content through proxy", function (t) {
+    t.ifError(err, "example package compressed")
+
+    t.deepEqual('http://localhost:8080', client.conf.get('proxy'))
+    t.deepEqual('localhost, .npmjs.org', client.conf.get('noproxy'))
+
+    server.expect("GET", "/test-package-gzip/1.2.3", function (req, res) {
+      res.statusCode = 200
+      res.setHeader("Content-Encoding", "gzip")
+      res.setHeader("Content-Type", "application/json")
+      res.end(pkgGzip)
+    })
+
+    client.get(TEST_URL, null, function (er, data) {
+      if (er) throw er
+      t.deepEqual(data, pkg)
+      t.end()
+    })
+  })
+
+})
+

--- a/test/proxy-request-gzip-content.js
+++ b/test/proxy-request-gzip-content.js
@@ -1,0 +1,44 @@
+var assert = require("assert")
+var zlib = require("zlib")
+var tap = require("tap")
+
+var server = require("./lib/server.js")
+var proxy = require("./lib/proxy.js")
+var common = require("./lib/common.js")
+var config = {
+  proxy: 'http://localhost:8080',
+  noproxy: ''
+}
+var client = common.freshClient(config)
+proxy.log = client.log;
+
+var TEST_URL = "http://localhost:1337/test-package-gzip/1.2.3"
+
+var pkg = {
+  _id: "proxy-package-gzip@1.2.3",
+  name: "proxy-package-gzip",
+  version: "1.2.3"
+}
+
+zlib.gzip(JSON.stringify(pkg), function (err, pkgGzip) {
+  tap.test("request gzip package content through proxy", function (t) {
+    t.ifError(err, "example package compressed")
+
+    t.deepEqual('http://localhost:8080', client.conf.get('proxy'))
+
+    server.expect("GET", "/proxy-package-gzip/1.2.3", function (req, res) {
+      res.statusCode = 200
+      res.setHeader("Content-Encoding", "gzip")
+      res.setHeader("Content-Type", "application/json")
+      res.end(pkgGzip)
+    })
+
+    client.get(TEST_URL, null, function (er, data) {
+      if (er) throw er
+      t.deepEqual(data, pkg)
+      t.end()
+    })
+  })
+
+})
+


### PR DESCRIPTION
Hello,

Proxy configuration seems to have moved from npm to npm-registry-client, so noproxy configuration should too.

> When fetching, check if the url requested must use a proxy (if present) or not.
> This allows package installation from lan without having to change/disable the proxy parameter each time.

Previous discussion about noproxy: npm/npm#2873

```
### noproxy

* Default: `NO_PROXY` or `no_proxy` environment variable, or ""
* Type: String

This variable should contain a comma-separated list of domain extensions proxy should not be used for. For instance, if the value of no_proxy is `.mit.edu', proxy will not be used to retrieve packages from MIT. 
```