### PR TITLE
Proposal: extend the fetch call to be used to only fetch HEAD

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -12,11 +12,15 @@ function fetch (uri, headers, cb) {
 
   if (!headers) headers = {}
 
+  // Workaround to not disrupt the fetch API with the missing method arg
+  var method = headers._method || "GET"
+  delete headers[_method]
+
   cb = once(cb)
 
   var client = this
   this.attempt(function (operation) {
-    makeRequest.call(client, uri, headers, function (er, req) {
+    makeRequest.call(client, uri, headers, method, function (er, req) {
       if (er) return cb(er)
 
       req.on("error", function (er) {
@@ -65,9 +69,9 @@ function unstick(response) {
   }}(response.resume)
 }
 
-function makeRequest (remote, headers, cb) {
+function makeRequest (remote, headers, method, cb) {
   var parsed = url.parse(remote)
-  this.log.http("fetch", "GET", parsed.href)
+  this.log.http("fetch", method, parsed.href)
 
   var er = this.authify(
     this.conf.getCredentialsByURI(remote).alwaysAuth,
@@ -78,7 +82,7 @@ function makeRequest (remote, headers, cb) {
 
   var opts = this.initialize(
     parsed,
-    "GET",
+    method,
     "application/x-tar",
     headers
   )


### PR DESCRIPTION
See original blocked enhancement request: https://github.com/npm/npm/pull/6208
Since the 'add-remote-tarball' module invokes the 'registry.fetch' command (that require the correct application/x-tar MIME type), I've tried to modify the fetch call itself to support HEAD method.

However I'm not sure what other users depends on that call, so I'm proposing an ugly workaround to pass in the method arg without changing the args (I've seen that the callback 'cb' par is always at the end of the list, so adding a new parameter seems more ugly).

Thank you,
 Luciano