### PR TITLE
fix connection keepalive on node 0.11.x

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -1,6 +1,11 @@
 var crypto = require("crypto")
+  , HttpAgent = require("http").Agent
+  , HttpsAgent = require("https").Agent
 
 var pkg = require("../package.json")
+
+var httpAgent = new HttpAgent({keepAlive: true})
+  , httpsAgent = new HttpsAgent({keepAlive: true})
 
 module.exports = initialize
 
@@ -24,11 +29,13 @@ function initialize (uri, method, accept, headers) {
   // request will not pay attention to the NOPROXY environment variable if a
   // config value named proxy is passed in, even if it's set to null.
   var proxy
-  if (uri.protocol === "https") {
+  if (uri.protocol === "https:") {
     proxy = this.config.proxy.https
+    opts.agent = httpsAgent
   }
   else {
     proxy = this.config.proxy.http
+    opts.agent = httpAgent
   }
   if (typeof proxy === "string") opts.proxy = proxy
 

--- a/test/lib/server.js
+++ b/test/lib/server.js
@@ -27,7 +27,7 @@ function handler (req, res) {
   if (!k) throw Error('unexpected request: ' + req.method + ' ' + req.url)
 
   var fn = server._expect[k].shift()
-  if (!fn) throw Error('unexpected request' + req.method + ' ' + req.url)
+  if (!fn) throw Error('unexpected request: ' + req.method + ' ' + req.url)
 
 
   var remain = (Object.keys(server._expect).reduce(function (s, k) {

--- a/test/request.js
+++ b/test/request.js
@@ -159,9 +159,10 @@ test("run request through its paces", function (t) {
   })
 
   var defaults = {}
-  client.request(common.registry+"/request-defaults", defaults, function (er, data) {
+  client.request(common.registry+"/request-defaults", defaults, function (er, data, raw, response) {
     t.ifError(er, "call worked")
     t.deepEquals(data, { fetched : "defaults" }, "confirmed defaults work")
+    t.equal(response.headers.connection, "keep-alive", "connection header kee-palive")
   })
 
   var etagged = { etag : "test-etag" }


### PR DESCRIPTION
globalAgent is not keepalive on node >= 0.11.0, so need to create
a keepalive agent to replace the global one.

## before

```bash
http request GET https://registry.npmjs.org/pedding
http 200 https://registry.npmjs.org/pedding
200 { date: 'Mon, 05 Jan 2015 04:43:03 GMT',
  server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
  etag: '"DJK919AFVMOJSSUUGBDP6AJMW"',
  'content-type': 'application/json',
  'cache-control': 'max-age=60',
  'content-length': '6599',
  'accept-ranges': 'bytes',
  via: '1.1 varnish',
  age: '20',
  'x-served-by': 'cache-ty67-TYO',
  'x-cache': 'HIT',
  'x-cache-hits': '2',
  'x-timer': 'S1420432983.532059,VS0,VE0',
  vary: 'Accept',
  connection: 'close' }
```

## after

```bash
http request GET https://registry.npmjs.org/pedding
http 200 https://registry.npmjs.org/pedding
200 { date: 'Mon, 05 Jan 2015 04:43:36 GMT',
  server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
  etag: '"DJK919AFVMOJSSUUGBDP6AJMW"',
  'content-type': 'application/json',
  'cache-control': 'max-age=60',
  'content-length': '6599',
  'accept-ranges': 'bytes',
  via: '1.1 varnish',
  age: '52',
  'x-served-by': 'cache-ty68-TYO',
  'x-cache': 'HIT',
  'x-cache-hits': '3',
  'x-timer': 'S1420433016.417979,VS0,VE0',
  vary: 'Accept',
  'keep-alive': 'timeout=10, max=50',
  connection: 'Keep-Alive' }
```