### PR TITLE
move whoami endpoint out of the package namespace

### DIFF
--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -11,7 +11,7 @@ function whoami (uri, params, cb) {
   var auth = params.auth
   assert(auth && typeof auth === "object", "must pass auth to whoami")
 
-  this.request(url.resolve(uri, "whoami"), { auth : auth }, function (er, userdata) {
+  this.request(url.resolve(uri, "-/whoami"), { auth : auth }, function (er, userdata) {
     if (er) return cb(er)
 
     cb(null, userdata.username)

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -11,7 +11,7 @@ function whoami (uri, params, cb) {
   var auth = params.auth
   assert(auth && typeof auth === "object", "must pass auth to whoami")
 
-  if (auth.username) process.nextTick(cb.bind(this, null, auth.username))
+  if (auth.username) return process.nextTick(cb.bind(this, null, auth.username))
 
   this.request(url.resolve(uri, "-/whoami"), { auth : auth }, function (er, userdata) {
     if (er) return cb(er)

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -11,6 +11,8 @@ function whoami (uri, params, cb) {
   var auth = params.auth
   assert(auth && typeof auth === "object", "must pass auth to whoami")
 
+  if (auth.username) process.nextTick(cb.bind(this, null, auth.username))
+
   this.request(url.resolve(uri, "-/whoami"), { auth : auth }, function (er, userdata) {
     if (er) return cb(er)
 

--- a/test/whoami.js
+++ b/test/whoami.js
@@ -49,10 +49,13 @@ test("whoami call contract", function (t) {
 })
 
 test("whoami", function (t) {
-  server.expect("GET", "/whoami", function (req, res) {
+  server.expect("GET", "/-/whoami", function (req, res) {
     t.equal(req.method, "GET")
     // only available for token-based auth for now
-    t.equal(req.headers.authorization, "Bearer not-bad-meaning-bad-but-bad-meaning-wombat")
+    t.equal(
+      req.headers.authorization,
+      "Bearer not-bad-meaning-bad-but-bad-meaning-wombat"
+    )
 
     res.json({username : WHOIAM})
   })


### PR DESCRIPTION
Does what it says on the tin. We should ensure that endpoints for `npm-registry-client`, `npmE`, and `registry-2` are all set for this command before rolling it into the CLI.

/cc @bcoe @seldo 