### PR TITLE
support registry 2 access endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ for authorization. These credentials always look the same:
 
 ## API
 
+### client.access(uri, params, cb)
+
+* `uri` {String} Registry URL for the package's access API endpoint.
+  Looks like `/-/package/<package name>/access`.
+* `params` {Object} Object containing per-request properties.
+  * `access` {String} New access level for the package. Can be either
+    `public` or `restricted`. Registry will raise an error if trying
+    to change the access level of an unscoped package.
+  * `auth` {Credentials}
+
+Set the access level for scoped packages. For now, there are only two
+access levels: "public" and "restricted".
+
 ### client.adduser(uri, params, cb)
 
 * `uri` {String} Base registry URL.

--- a/lib/access.js
+++ b/lib/access.js
@@ -1,0 +1,30 @@
+module.exports = access
+
+var assert = require("assert")
+
+function access (uri, params, cb) {
+  assert(typeof uri === "string", "must pass registry URI to access")
+  assert(params && typeof params === "object", "must pass params to access")
+  assert(typeof cb === "function", "muss pass callback to access")
+
+  assert(typeof params.level === "string", "must pass level to access")
+  assert(
+    ["public", "restricted"].indexOf(params.level) !== -1,
+    "access level must be either 'public' or 'restricted'"
+  )
+  assert(
+    params.auth && typeof params.auth === "object",
+    "must pass auth to access"
+  )
+
+  var body = {
+    access : params.level
+  }
+
+  var options = {
+    method : "POST",
+    body : JSON.stringify(body),
+    auth : params.auth
+  }
+  this.request(uri, options, cb)
+}

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -9,7 +9,10 @@ function tag (uri, params, cb) {
 
   assert(typeof params.version === "string", "must pass version to tag")
   assert(typeof params.tag === "string", "must pass tag name to tag")
-  assert(params.auth && typeof params.auth === "object", "must pass auth to tag")
+  assert(
+    params.auth && typeof params.auth === "object",
+    "must pass auth to tag"
+  )
 
   var options = {
     method : "PUT",

--- a/test/access.js
+++ b/test/access.js
@@ -1,0 +1,96 @@
+var test = require("tap").test
+
+var server = require("./lib/server.js")
+var common = require("./lib/common.js")
+var client = common.freshClient()
+
+function nop() {}
+
+var URI = "http://localhost:1337/-/package/underscore/access"
+var TOKEN = "foo"
+var AUTH = {
+  token : TOKEN
+}
+var LEVEL = "public"
+var PARAMS = {
+  level : LEVEL,
+  auth : AUTH
+}
+
+test("access call contract", function (t) {
+  t.throws(function () {
+    client.access(undefined, AUTH, nop)
+  }, "requires a URI")
+
+  t.throws(function () {
+    client.access([], PARAMS, nop)
+  }, "requires URI to be a string")
+
+  t.throws(function () {
+    client.access(URI, undefined, nop)
+  }, "requires params object")
+
+  t.throws(function () {
+    client.access(URI, "", nop)
+  }, "params must be object")
+
+  t.throws(function () {
+    client.access(URI, PARAMS, undefined)
+  }, "requires callback")
+
+  t.throws(function () {
+    client.access(URI, PARAMS, "callback")
+  }, "callback must be function")
+
+  t.throws(
+    function () {
+      var params = {
+        auth : AUTH
+      }
+      client.access(URI, params, nop)
+    },
+    { name : "AssertionError", message : "must pass level to access" },
+    "access must include level"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        level : LEVEL
+      }
+      client.access(URI, params, nop)
+    },
+    { name : "AssertionError", message : "must pass auth to access" },
+    "access must include auth"
+  )
+
+  t.end()
+})
+
+test("set access level on a package", function (t) {
+  server.expect("POST", "/-/package/underscore/access", function (req, res) {
+    t.equal(req.method, "POST")
+
+    var b = ""
+    req.setEncoding("utf8")
+    req.on("data", function (d) {
+      b += d
+    })
+
+    req.on("end", function () {
+      var updated = JSON.parse(b)
+
+      t.deepEqual(updated, { access : "public" })
+
+      res.statusCode = 201
+      res.json({accessChanged : true})
+    })
+  })
+
+  client.access(URI, PARAMS, function (error, data) {
+    t.ifError(error, "no errors")
+    t.ok(data.accessChanged, "access level set")
+
+    t.end()
+  })
+})

--- a/test/tag.js
+++ b/test/tag.js
@@ -57,7 +57,7 @@ test("tag call contract", function (t) {
       client.tag(URI, params, nop)
     },
     { name : "AssertionError", message : "must pass version to tag" },
-    "auth must include username"
+    "tag must include version"
   )
 
   t.throws(
@@ -69,7 +69,7 @@ test("tag call contract", function (t) {
       client.tag(URI, params, nop)
     },
     { name : "AssertionError", message : "must pass tag name to tag" },
-    "auth must include username"
+    "tag must include name"
   )
 
   t.throws(
@@ -81,7 +81,7 @@ test("tag call contract", function (t) {
       client.tag(URI, params, nop)
     },
     { name : "AssertionError", message : "must pass auth to tag" },
-    "auth must include username"
+    "params must include auth"
   )
 
   t.end()


### PR DESCRIPTION
#### access registry API

```javascript
var method = "POST"
var path = "/-/package/<package name>/access"

var headers = {
  "authorization" : "bearer XXXXX-XXXXX-XXXX"
  // note: NOT using "referer" -- explicit endpoint instead
}

var body = {
  access: "<'restricted'|'public'>"
}
res.end(JSON.stringify(body))
```

review: @iarna
review: @bcoe 