### PR TITLE
`dist-tag` client methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,67 @@ Add a user account to the registry, or verify the credentials.
 
 Deprecate a version of a package in the registry.
 
+### client.distTags.fetch(uri, params, cb)
+
+* `uri` {String} Base URL for the registry.
+* `params` {Object} Object containing per-request properties.
+  * `package` {String} Name of the package.
+  * `auth` {Credentials}
+* `cb` {Function}
+
+Fetch all of the `dist-tags` for the named package.
+
+### client.distTags.add(uri, params, cb)
+
+* `uri` {String} Base URL for the registry.
+* `params` {Object} Object containing per-request properties.
+  * `package` {String} Name of the package.
+  * `distTag` {String} Name of the new `dist-tag`.
+  * `version` {String} Exact version to be mapped to the `dist-tag`.
+  * `auth` {Credentials}
+* `cb` {Function}
+
+Add (or replace) a single dist-tag onto the named package.
+
+### client.distTags.set(uri, params, cb)
+
+* `uri` {String} Base URL for the registry.
+* `params` {Object} Object containing per-request properties.
+  * `package` {String} Name of the package.
+  * `distTags` {Object} Object containing a map from tag names to package
+     versions.
+  * `auth` {Credentials}
+* `cb` {Function}
+
+Set all of the `dist-tags` for the named package at once, creating any
+`dist-tags` that do not already exit. Any `dist-tags` not included in the
+`distTags` map will be removed.
+
+### client.distTags.update(uri, params, cb)
+
+* `uri` {String} Base URL for the registry.
+* `params` {Object} Object containing per-request properties.
+  * `package` {String} Name of the package.
+  * `distTags` {Object} Object containing a map from tag names to package
+     versions.
+  * `auth` {Credentials}
+* `cb` {Function}
+
+Update the values of multiple `dist-tags`, creating any `dist-tags` that do
+not already exist. Any pre-existing `dist-tags` not included in the `distTags`
+map will be left alone.
+
+### client.distTags.rm(uri, params, cb)
+
+* `uri` {String} Base URL for the registry.
+* `params` {Object} Object containing per-request properties.
+  * `package` {String} Name of the package.
+  * `distTag` {String} Name of the new `dist-tag`.
+  * `auth` {Credentials}
+* `cb` {Function}
+
+Remove a single `dist-tag` from the named package.
+
 ### client.get(uri, params, cb)
 
 * `uri` {String} The complete registry URI to fetch

--- a/lib/dist-tags/add.js
+++ b/lib/dist-tags/add.js
@@ -1,0 +1,43 @@
+module.exports = add
+
+var assert = require("assert")
+var url = require("url")
+
+var npa = require("npm-package-arg")
+
+function add (uri, params, cb) {
+  assert(typeof uri === "string", "must pass registry URI to distTags.add")
+  assert(
+    params && typeof params === "object",
+    "must pass params to distTags.add"
+  )
+  assert(typeof cb === "function", "muss pass callback to distTags.add")
+
+  assert(
+    typeof params.package === "string",
+    "must pass package name to distTags.add"
+  )
+  assert(
+    typeof params.distTag === "string",
+    "must pass package distTag name to distTags.add"
+  )
+  assert(
+    typeof params.version === "string",
+    "must pass version to be mapped to distTag to distTags.add"
+  )
+  assert(
+    params.auth && typeof params.auth === "object",
+    "must pass auth to distTags.add"
+  )
+
+  var p = npa(params.package)
+  var package = p.scope ? params.package.replace("/", "%2f") : params.package
+  var rest = "-/package/"+package+"/dist-tags/"+params.distTag
+
+  var options = {
+    method : "PUT",
+    body : params.version,
+    auth : params.auth
+  }
+  this.request(url.resolve(uri, rest), options, cb)
+}

--- a/lib/dist-tags/fetch.js
+++ b/lib/dist-tags/fetch.js
@@ -1,0 +1,34 @@
+module.exports = fetch
+
+var assert = require("assert")
+var url = require("url")
+
+var npa = require("npm-package-arg")
+
+function fetch (uri, params, cb) {
+  assert(typeof uri === "string", "must pass registry URI to distTags.fetch")
+  assert(
+    params && typeof params === "object",
+    "must pass params to distTags.fetch"
+  )
+  assert(typeof cb === "function", "muss pass callback to distTags.fetch")
+
+  assert(
+    typeof params.package === "string",
+    "must pass package name to distTags.fetch"
+  )
+  assert(
+    params.auth && typeof params.auth === "object",
+    "must pass auth to distTags.fetch"
+  )
+
+  var p = npa(params.package)
+  var package = p.scope ? params.package.replace("/", "%2f") : params.package
+  var rest = "-/package/"+package+"/dist-tags"
+
+  var options = {
+    method : "GET",
+    auth : params.auth
+  }
+  this.request(url.resolve(uri, rest), options, cb)
+}

--- a/lib/dist-tags/rm.js
+++ b/lib/dist-tags/rm.js
@@ -1,0 +1,38 @@
+module.exports = rm
+
+var assert = require("assert")
+var url = require("url")
+
+var npa = require("npm-package-arg")
+
+function rm (uri, params, cb) {
+  assert(typeof uri === "string", "must pass registry URI to distTags.rm")
+  assert(
+    params && typeof params === "object",
+    "must pass params to distTags.rm"
+  )
+  assert(typeof cb === "function", "muss pass callback to distTags.rm")
+
+  assert(
+    typeof params.package === "string",
+    "must pass package name to distTags.rm"
+  )
+  assert(
+    typeof params.distTag === "string",
+    "must pass package distTag name to distTags.rm"
+  )
+  assert(
+    params.auth && typeof params.auth === "object",
+    "must pass auth to distTags.rm"
+  )
+
+  var p = npa(params.package)
+  var package = p.scope ? params.package.replace("/", "%2f") : params.package
+  var rest = "-/package/"+package+"/dist-tags/"+params.distTag
+
+  var options = {
+    method : "DELETE",
+    auth : params.auth
+  }
+  this.request(url.resolve(uri, rest), options, cb)
+}

--- a/lib/dist-tags/set.js
+++ b/lib/dist-tags/set.js
@@ -1,0 +1,39 @@
+module.exports = set
+
+var assert = require("assert")
+var url = require("url")
+
+var npa = require("npm-package-arg")
+
+function set (uri, params, cb) {
+  assert(typeof uri === "string", "must pass registry URI to distTags.set")
+  assert(
+    params && typeof params === "object",
+    "must pass params to distTags.set"
+  )
+  assert(typeof cb === "function", "muss pass callback to distTags.set")
+
+  assert(
+    typeof params.package === "string",
+    "must pass package name to distTags.set"
+  )
+  assert(
+    params.distTags && typeof params.distTags === "object",
+    "must pass distTags map to distTags.set"
+  )
+  assert(
+    params.auth && typeof params.auth === "object",
+    "must pass auth to distTags.set"
+  )
+
+  var p = npa(params.package)
+  var package = p.scope ? params.package.replace("/", "%2f") : params.package
+  var rest = "-/package/"+package+"/dist-tags"
+
+  var options = {
+    method : "PUT",
+    body : JSON.stringify(params.distTags),
+    auth : params.auth
+  }
+  this.request(url.resolve(uri, rest), options, cb)
+}

--- a/lib/dist-tags/update.js
+++ b/lib/dist-tags/update.js
@@ -1,0 +1,39 @@
+module.exports = update
+
+var assert = require("assert")
+var url = require("url")
+
+var npa = require("npm-package-arg")
+
+function update (uri, params, cb) {
+  assert(typeof uri === "string", "must pass registry URI to distTags.update")
+  assert(
+    params && typeof params === "object",
+    "must pass params to distTags.update"
+  )
+  assert(typeof cb === "function", "muss pass callback to distTags.update")
+
+  assert(
+    typeof params.package === "string",
+    "must pass package name to distTags.update"
+  )
+  assert(
+    params.distTags && typeof params.distTags === "object",
+    "must pass distTags map to distTags.update"
+  )
+  assert(
+    params.auth && typeof params.auth === "object",
+    "must pass auth to distTags.update"
+  )
+
+  var p = npa(params.package)
+  var package = p.scope ? params.package.replace("/", "%2f") : params.package
+  var rest = "-/package/"+package+"/dist-tags"
+
+  var options = {
+    method : "POST",
+    body : JSON.stringify(params.distTags),
+    auth : params.auth
+  }
+  this.request(url.resolve(uri, rest), options, cb)
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "graceful-fs": "^3.0.0",
     "mkdirp": "^0.5.0",
     "normalize-package-data": "~1.0.1",
+    "npm-package-arg": "^3.0.0",
     "once": "^1.3.0",
     "request": "^2.47.0",
     "retry": "^0.6.1",

--- a/test/dist-tags-add.js
+++ b/test/dist-tags-add.js
@@ -1,0 +1,138 @@
+var test = require("tap").test
+
+var server = require("./lib/server.js")
+var common = require("./lib/common.js")
+var client = common.freshClient()
+
+function nop() {}
+
+var BASE_URL = "http://localhost:1337/"
+var URI = "/-/package/underscore/dist-tags/test"
+var TOKEN = "foo"
+var AUTH = {
+  token : TOKEN
+}
+var PACKAGE = "underscore"
+var DIST_TAG = "test"
+var VERSION = "3.1.3"
+var PARAMS = {
+  package : PACKAGE,
+  distTag : DIST_TAG,
+  version : VERSION,
+  auth : AUTH
+}
+
+test("distTags.add call contract", function (t) {
+  t.throws(function () {
+    client.distTags.add(undefined, AUTH, nop)
+  }, "requires a URI")
+
+  t.throws(function () {
+    client.distTags.add([], PARAMS, nop)
+  }, "requires URI to be a string")
+
+  t.throws(function () {
+    client.distTags.add(BASE_URL, undefined, nop)
+  }, "requires params object")
+
+  t.throws(function () {
+    client.distTags.add(BASE_URL, "", nop)
+  }, "params must be object")
+
+  t.throws(function () {
+    client.distTags.add(BASE_URL, PARAMS, undefined)
+  }, "requires callback")
+
+  t.throws(function () {
+    client.distTags.add(BASE_URL, PARAMS, "callback")
+  }, "callback must be function")
+
+  t.throws(
+    function () {
+      var params = {
+        distTag : DIST_TAG,
+        version : VERSION,
+        auth : AUTH
+      }
+      client.distTags.add(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass package name to distTags.add"
+    },
+    "distTags.add must include package name"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE,
+        version : VERSION,
+        auth : AUTH
+      }
+      client.distTags.add(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass package distTag name to distTags.add"
+    },
+    "distTags.add must include dist-tag"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE,
+        distTag : DIST_TAG,
+        auth : AUTH
+      }
+      client.distTags.add(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass version to be mapped to distTag to distTags.add"
+    },
+    "distTags.add must include version"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE,
+        distTag : DIST_TAG,
+        version : VERSION
+      }
+      client.distTags.add(BASE_URL, params, nop)
+    },
+    { name : "AssertionError", message : "must pass auth to distTags.add" },
+    "distTags.add must include auth"
+  )
+
+  t.end()
+})
+
+test("add a new dist-tag to a package", function (t) {
+  server.expect("PUT", URI, function (req, res) {
+    t.equal(req.method, "PUT")
+
+    var b = ""
+    req.setEncoding("utf8")
+    req.on("data", function (d) {
+      b += d
+    })
+
+    req.on("end", function () {
+      t.deepEqual(b, VERSION)
+
+      res.statusCode = 200
+      res.json({ "test" : VERSION })
+    })
+  })
+
+  client.distTags.add(BASE_URL, PARAMS, function (error, data) {
+    t.ifError(error, "no errors")
+    t.ok(data.test, "dist-tag added")
+
+    t.end()
+  })
+})

--- a/test/dist-tags-fetch.js
+++ b/test/dist-tags-fetch.js
@@ -1,0 +1,98 @@
+var test = require("tap").test
+
+var server = require("./lib/server.js")
+var common = require("./lib/common.js")
+var client = common.freshClient()
+
+function nop() {}
+
+var BASE_URL = "http://localhost:1337/"
+var URI = "/-/package/underscore/dist-tags"
+var TOKEN = "foo"
+var AUTH = {
+  token : TOKEN
+}
+var PACKAGE = "underscore"
+var PARAMS = {
+  package : PACKAGE,
+  auth : AUTH
+}
+
+test("distTags.fetch call contract", function (t) {
+  t.throws(function () {
+    client.distTags.fetch(undefined, AUTH, nop)
+  }, "requires a URI")
+
+  t.throws(function () {
+    client.distTags.fetch([], PARAMS, nop)
+  }, "requires URI to be a string")
+
+  t.throws(function () {
+    client.distTags.fetch(BASE_URL, undefined, nop)
+  }, "requires params object")
+
+  t.throws(function () {
+    client.distTags.fetch(BASE_URL, "", nop)
+  }, "params must be object")
+
+  t.throws(function () {
+    client.distTags.fetch(BASE_URL, PARAMS, undefined)
+  }, "requires callback")
+
+  t.throws(function () {
+    client.distTags.fetch(BASE_URL, PARAMS, "callback")
+  }, "callback must be function")
+
+  t.throws(
+    function () {
+      var params = {
+        auth : AUTH
+      }
+      client.distTags.fetch(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass package name to distTags.fetch"
+    },
+    "distTags.fetch must include package name"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE
+      }
+      client.distTags.fetch(BASE_URL, params, nop)
+    },
+    { name : "AssertionError", message : "must pass auth to distTags.fetch" },
+    "distTags.fetch must include auth"
+  )
+
+  t.end()
+})
+
+test("fetch dist-tags for a package", function (t) {
+  server.expect("GET", URI, function (req, res) {
+    t.equal(req.method, "GET")
+
+    var b = ""
+    req.setEncoding("utf8")
+    req.on("data", function (d) {
+      b += d
+    })
+
+    req.on("end", function () {
+      t.notOk(b, "no request body")
+
+      res.statusCode = 200
+      res.json({ a : "1.0.0", b : "2.0.0" })
+    })
+  })
+
+  client.distTags.fetch(BASE_URL, PARAMS, function (error, data) {
+    t.ifError(error, "no errors")
+    t.notOk(data.test, "dist-tag removed")
+
+    t.end()
+  })
+})

--- a/test/dist-tags-rm.js
+++ b/test/dist-tags-rm.js
@@ -1,0 +1,117 @@
+var test = require("tap").test
+
+var server = require("./lib/server.js")
+var common = require("./lib/common.js")
+var client = common.freshClient()
+
+function nop() {}
+
+var BASE_URL = "http://localhost:1337/"
+var URI = "/-/package/underscore/dist-tags/test"
+var TOKEN = "foo"
+var AUTH = {
+  token : TOKEN
+}
+var PACKAGE = "underscore"
+var DIST_TAG = "test"
+var PARAMS = {
+  package : PACKAGE,
+  distTag : DIST_TAG,
+  auth : AUTH
+}
+
+test("distTags.rm call contract", function (t) {
+  t.throws(function () {
+    client.distTags.rm(undefined, AUTH, nop)
+  }, "requires a URI")
+
+  t.throws(function () {
+    client.distTags.rm([], PARAMS, nop)
+  }, "requires URI to be a string")
+
+  t.throws(function () {
+    client.distTags.rm(BASE_URL, undefined, nop)
+  }, "requires params object")
+
+  t.throws(function () {
+    client.distTags.rm(BASE_URL, "", nop)
+  }, "params must be object")
+
+  t.throws(function () {
+    client.distTags.rm(BASE_URL, PARAMS, undefined)
+  }, "requires callback")
+
+  t.throws(function () {
+    client.distTags.rm(BASE_URL, PARAMS, "callback")
+  }, "callback must be function")
+
+  t.throws(
+    function () {
+      var params = {
+        distTag : DIST_TAG,
+        auth : AUTH
+      }
+      client.distTags.rm(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass package name to distTags.rm"
+    },
+    "distTags.rm must include package name"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE,
+        auth : AUTH
+      }
+      client.distTags.rm(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass package distTag name to distTags.rm"
+    },
+    "distTags.rm must include dist-tag"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE,
+        distTag : DIST_TAG
+      }
+      client.distTags.rm(BASE_URL, params, nop)
+    },
+    { name : "AssertionError", message : "must pass auth to distTags.rm" },
+    "distTags.rm must include auth"
+  )
+
+  t.end()
+})
+
+test("remove a dist-tag from a package", function (t) {
+  server.expect("DELETE", URI, function (req, res) {
+    t.equal(req.method, "DELETE")
+
+    var b = ""
+    req.setEncoding("utf8")
+    req.on("data", function (d) {
+      b += d
+    })
+
+    req.on("end", function () {
+      t.notOk(b, "got no message body")
+
+      res.statusCode = 200
+      res.json({})
+    })
+  })
+
+  client.distTags.rm(BASE_URL, PARAMS, function (error, data) {
+    t.ifError(error, "no errors")
+    t.notOk(data.test, "dist-tag removed")
+
+    t.end()
+  })
+})

--- a/test/dist-tags-set.js
+++ b/test/dist-tags-set.js
@@ -1,0 +1,121 @@
+var test = require("tap").test
+
+var server = require("./lib/server.js")
+var common = require("./lib/common.js")
+var client = common.freshClient()
+
+function nop() {}
+
+var BASE_URL = "http://localhost:1337/"
+var URI = "/-/package/underscore/dist-tags"
+var TOKEN = "foo"
+var AUTH = {
+  token : TOKEN
+}
+var PACKAGE = "underscore"
+var DIST_TAGS = {
+  "a" : "8.0.8",
+  "b" : "3.0.3"
+}
+var PARAMS = {
+  package : PACKAGE,
+  distTags : DIST_TAGS,
+  auth : AUTH
+}
+
+test("distTags.set call contract", function (t) {
+  t.throws(function () {
+    client.distTags.set(undefined, AUTH, nop)
+  }, "requires a URI")
+
+  t.throws(function () {
+    client.distTags.set([], PARAMS, nop)
+  }, "requires URI to be a string")
+
+  t.throws(function () {
+    client.distTags.set(BASE_URL, undefined, nop)
+  }, "requires params object")
+
+  t.throws(function () {
+    client.distTags.set(BASE_URL, "", nop)
+  }, "params must be object")
+
+  t.throws(function () {
+    client.distTags.set(BASE_URL, PARAMS, undefined)
+  }, "requires callback")
+
+  t.throws(function () {
+    client.distTags.set(BASE_URL, PARAMS, "callback")
+  }, "callback must be function")
+
+  t.throws(
+    function () {
+      var params = {
+        distTags : DIST_TAGS,
+        auth : AUTH
+      }
+      client.distTags.set(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass package name to distTags.set"
+    },
+    "distTags.set must include package name"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE,
+        auth : AUTH
+      }
+      client.distTags.set(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass distTags map to distTags.set"
+    },
+    "distTags.set must include dist-tags"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE,
+        distTags : DIST_TAGS
+      }
+      client.distTags.set(BASE_URL, params, nop)
+    },
+    { name : "AssertionError", message : "must pass auth to distTags.set" },
+    "distTags.set must include auth"
+  )
+
+  t.end()
+})
+
+test("set dist-tags for a package", function (t) {
+  server.expect("PUT", URI, function (req, res) {
+    t.equal(req.method, "PUT")
+
+    var b = ""
+    req.setEncoding("utf8")
+    req.on("data", function (d) {
+      b += d
+    })
+
+    req.on("end", function () {
+      var d = JSON.parse(b)
+      t.deepEqual(d, DIST_TAGS, "got back tags")
+
+      res.statusCode = 200
+      res.json(DIST_TAGS)
+    })
+  })
+
+  client.distTags.set(BASE_URL, PARAMS, function (error, data) {
+    t.ifError(error, "no errors")
+    t.ok(data.a && data.b, "dist-tags set")
+
+    t.end()
+  })
+})

--- a/test/dist-tags-update.js
+++ b/test/dist-tags-update.js
@@ -1,0 +1,121 @@
+var test = require("tap").test
+
+var server = require("./lib/server.js")
+var common = require("./lib/common.js")
+var client = common.freshClient()
+
+function nop() {}
+
+var BASE_URL = "http://localhost:1337/"
+var URI = "/-/package/underscore/dist-tags"
+var TOKEN = "foo"
+var AUTH = {
+  token : TOKEN
+}
+var PACKAGE = "underscore"
+var DIST_TAGS = {
+  "a" : "8.0.8",
+  "b" : "3.0.3"
+}
+var PARAMS = {
+  package : PACKAGE,
+  distTags : DIST_TAGS,
+  auth : AUTH
+}
+
+test("distTags.update call contract", function (t) {
+  t.throws(function () {
+    client.distTags.update(undefined, AUTH, nop)
+  }, "requires a URI")
+
+  t.throws(function () {
+    client.distTags.update([], PARAMS, nop)
+  }, "requires URI to be a string")
+
+  t.throws(function () {
+    client.distTags.update(BASE_URL, undefined, nop)
+  }, "requires params object")
+
+  t.throws(function () {
+    client.distTags.update(BASE_URL, "", nop)
+  }, "params must be object")
+
+  t.throws(function () {
+    client.distTags.update(BASE_URL, PARAMS, undefined)
+  }, "requires callback")
+
+  t.throws(function () {
+    client.distTags.update(BASE_URL, PARAMS, "callback")
+  }, "callback must be function")
+
+  t.throws(
+    function () {
+      var params = {
+        distTags : DIST_TAGS,
+        auth : AUTH
+      }
+      client.distTags.update(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass package name to distTags.update"
+    },
+    "distTags.update must include package name"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE,
+        auth : AUTH
+      }
+      client.distTags.update(BASE_URL, params, nop)
+    },
+    {
+      name : "AssertionError",
+      message : "must pass distTags map to distTags.update"
+    },
+    "distTags.update must include dist-tags"
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        package : PACKAGE,
+        distTags : DIST_TAGS
+      }
+      client.distTags.update(BASE_URL, params, nop)
+    },
+    { name : "AssertionError", message : "must pass auth to distTags.update" },
+    "distTags.update must include auth"
+  )
+
+  t.end()
+})
+
+test("update dist-tags for a package", function (t) {
+  server.expect("POST", URI, function (req, res) {
+    t.equal(req.method, "POST")
+
+    var b = ""
+    req.setEncoding("utf8")
+    req.on("data", function (d) {
+      b += d
+    })
+
+    req.on("end", function () {
+      var d = JSON.parse(b)
+      t.deepEqual(d, DIST_TAGS, "got back tags")
+
+      res.statusCode = 200
+      res.json(DIST_TAGS)
+    })
+  })
+
+  client.distTags.update(BASE_URL, PARAMS, function (error, data) {
+    t.ifError(error, "no errors")
+    t.ok(data.a && data.b, "dist-tags set")
+
+    t.end()
+  })
+})


### PR DESCRIPTION
Add support for the new `dist-tag` endpoints being added to `npm-registry-couchapp`.

review: @isaacs 
review: @bcoe 