### PR TITLE
add support for scope packages in private npm registries

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -84,7 +84,8 @@ function putFirst (registry, data, tarbuffer, access, auth, cb) {
   root["dist-tags"][tag] = data.version
 
   var tbName = data.name + "-" + data.version + ".tgz"
-    , tbURI = data.name + "/-/" + tbName
+    , tbNameEscaped = escaped(data.name) + "-" + data.version + ".tgz"
+    , tbURI = escaped(data.name) + "/-/" + tbNameEscaped
 
   data._id = data.name+"@"+data.version
   data.dist = data.dist || {}


### PR DESCRIPTION
The URI for the tarball when publishing a module seems to be broken for modules with scopes. Scopes are (currently) only supported in private registries with users who have admin access to the registry DB. The module name is not correctly escaped when the URI is generated.