### PR TITLE
Use a https schema so the example works

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It handles all the caching and HTTP calls.
 ```javascript
 var RegClient = require('npm-registry-client')
 var client = new RegClient(config)
-var uri = "npm://registry.npmjs.org/npm"
+var uri = "https://registry.npmjs.org/npm"
 var params = {timeout: 1000}
 
 client.get(uri, params, function (error, data, raw, res) {


### PR DESCRIPTION
When you try and run the example with the latest version of the lib it throws the following. This PR changes the example to use https, which works.

```
assert.js:93
  throw new assert.AssertionError({
        ^
AssertionError: must have a URL that starts with http: or https:
```