### PR TITLE
Fix ssl.certificate miscommunication

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -65,7 +65,7 @@ function getAgent (protocol, config) {
         localAddress       : config.proxy.localAddress,
         rejectUnauthorized : config.ssl.strict,
         ca                 : config.ssl.ca,
-        cert               : config.ssl.cert,
+        cert               : config.ssl.certificate,
         key                : config.ssl.key
       })
     }

--- a/test/initialize.js
+++ b/test/initialize.js
@@ -72,3 +72,20 @@ test("initializing with proxy undefined", function (t) {
   t.notOk("proxy" in options, "proxy can be read from env.PROXY by request")
   t.end()
 })
+
+test("initializing with a certificate should map down to the https agent", function (t) {
+  var certificate = '-----BEGIN CERTIFICATE----- TEST\nTEST -----END CERTIFICATE-----\n'
+  var client = new Client({
+    ssl: {
+      certificate: certificate
+    }
+  })
+  var options = client.initialize(
+    { protocol: "https:" },
+    "GET",
+    "application/json",
+    {}
+  )
+  t.equal(options.agent.options.cert, certificate, "certificate will be saved properly on agent")
+  t.end()
+})


### PR DESCRIPTION
I'm unable to get the `npm --cert` option to work properly when running the cli (partly because I'm noob also, please see https://github.com/npm/npm/issues/7672 for more background on this).

If I understand the documentation for this repository correctly, this might be the issue causing my problems.

This should fix https://github.com/npm/npm-registry-client/issues/103