### PR TITLE
Decode the package name from the request URL

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -232,7 +232,7 @@ function requestDone (method, where, cb) {
       var name
       if (!w.match(/^-/)) {
         w = w.split('/')
-        name = w[w.indexOf('_rewrite') + 1]
+        name = decodeURIComponent(w[w.indexOf('_rewrite') + 1])
       }
 
       if (!parsed.error) {
@@ -245,7 +245,7 @@ function requestDone (method, where, cb) {
         er = new Error('404 Not Found: ' + name)
       } else {
         er = new Error(
-          parsed.error + ' ' + (parsed.reason || '') + ': ' + w
+          parsed.error + ' ' + (parsed.reason || '') + ': ' + (name || w)
         )
       }
       if (name) er.pkgid = name

--- a/test/request.js
+++ b/test/request.js
@@ -81,7 +81,7 @@ test('request call contract', function (t) {
 })
 
 test('run request through its paces', function (t) {
-  t.plan(27)
+  t.plan(28)
 
   server.expect('/request-defaults', function (req, res) {
     t.equal(req.method, 'GET', 'uses GET by default')
@@ -163,6 +163,13 @@ test('run request through its paces', function (t) {
     req.pipe(concat(function () {
       res.statusCode = 200
       res.json({ error: {} })
+    }))
+  })
+
+  server.expect('GET', '/@scoped%2Fpackage-failing', function (req, res) {
+    req.pipe(concat(function () {
+      res.statusCode = 402
+      res.json({ error: 'payment required' })
     }))
   })
 
@@ -248,5 +255,9 @@ test('run request through its paces', function (t) {
 
   client.request(common.registry + '/body-error-object', defaults, function (er) {
     t.ifError(er, 'call worked')
+  })
+
+  client.request(common.registry + '/@scoped%2Fpackage-failing', defaults, function (er) {
+    t.equals(er.message, 'payment required : @scoped/package-failing')
   })
 })


### PR DESCRIPTION
Present the decoded package name in the error message if present.

Fixes npm/registry-frontdoor#116.
Fixes npm/npme-auth-userapi#16.