### PR TITLE
team: implemented api for npm team

### DIFF
--- a/lib/access.js
+++ b/lib/access.js
@@ -1,30 +1,153 @@
 module.exports = access
 
 var assert = require('assert')
+var url = require('url')
+var npa = require('npm-package-arg')
+var subcommands = {}
 
-function access (uri, params, cb) {
-  assert(typeof uri === 'string', 'must pass registry URI to access')
-  assert(params && typeof params === 'object', 'must pass params to access')
-  assert(typeof cb === 'function', 'muss pass callback to access')
+function access (sub, uri, params, cb) {
+  accessAssertions(sub, uri, params, cb)
+  return subcommands[sub].call(this, uri, params, cb)
+}
 
-  assert(typeof params.level === 'string', 'must pass level to access')
-  assert(
-    ['public', 'restricted'].indexOf(params.level) !== -1,
-    "access level must be either 'public' or 'restricted'"
-  )
-  assert(
-    params.auth && typeof params.auth === 'object',
-    'must pass auth to access'
-  )
+subcommands.public = function (uri, params, cb) {
+  return setAccess.call(this, 'public', uri, params, cb)
+}
+subcommands.restricted = function (uri, params, cb) {
+  return setAccess.call(this, 'restricted', uri, params, cb)
+}
 
-  var body = {
-    access: params.level
-  }
-
-  var options = {
+function setAccess (access, uri, params, cb) {
+  return this.request(apiUri(uri, 'package', params.package, 'access'), {
     method: 'POST',
-    body: JSON.stringify(body),
+    auth: params.auth,
+    body: JSON.stringify({ access: access })
+  }, cb)
+}
+
+subcommands.grant = function (uri, params, cb) {
+  var reqUri = apiUri(uri, 'team', params.scope, params.team, 'package')
+  return this.request(reqUri, {
+    method: 'PUT',
+    auth: params.auth,
+    body: JSON.stringify({
+      permissions: params.permissions,
+      package: params.package
+    })
+  }, cb)
+}
+
+subcommands.revoke = function (uri, params, cb) {
+  var reqUri = apiUri(uri, 'team', params.scope, params.team, 'package')
+  return this.request(reqUri, {
+    method: 'DELETE',
+    auth: params.auth,
+    body: JSON.stringify({
+      package: params.package
+    })
+  }, cb)
+}
+
+subcommands['ls-packages'] = function (uri, params, cb, type) {
+  type = type || (params.team ? 'team' : 'org')
+  var client = this
+  var uriParams = '?format=cli'
+  var reqUri = apiUri(uri, type, params.scope, params.team, 'package')
+  return client.request(reqUri + uriParams, {
+    method: 'GET',
     auth: params.auth
+  }, function (err, perms) {
+    if (err && err.statusCode === 404 && type === 'org') {
+      subcommands['ls-packages'].call(client, uri, params, cb, 'user')
+    } else {
+      cb(err, perms && translatePermissions(perms))
+    }
+  })
+}
+
+subcommands['ls-collaborators'] = function (uri, params, cb) {
+  var uriParams = '?format=cli'
+  if (params.user) {
+    uriParams += ('&user=' + encodeURIComponent(params.user))
   }
-  this.request(uri, options, cb)
+  var reqUri = apiUri(uri, 'package', params.package, 'collaborators')
+  return this.request(reqUri + uriParams, {
+    method: 'GET',
+    auth: params.auth
+  }, function (err, perms) {
+    cb(err, perms && translatePermissions(perms))
+  })
+}
+
+subcommands.edit = function () {
+  throw new Error('edit subcommand is not implemented yet')
+}
+
+function apiUri (registryUri) {
+  var path = Array.prototype.slice.call(arguments, 1)
+    .filter(function (x) { return x })
+    .map(encodeURIComponent)
+    .join('/')
+  return url.resolve(registryUri, '-/' + path)
+}
+
+function accessAssertions (subcommand, uri, params, cb) {
+  assert(subcommands.hasOwnProperty(subcommand),
+         'access subcommand must be one of ' +
+         Object.keys(subcommands).join(', '))
+  typeChecks({
+    'uri': [uri, 'string'],
+    'params': [params, 'object'],
+    'auth': [params.auth, 'object'],
+    'callback': [cb, 'function']
+  })
+  if (contains([
+    'public', 'restricted', 'grant', 'revoke', 'ls-collaborators'
+  ], subcommand)) {
+    typeChecks({ 'package': [params.package, 'string']})
+    assert(!!npa(params.package).scope,
+           'access commands are only accessible for scoped packages')
+  }
+  if (contains(['grant', 'revoke', 'ls-packages'], subcommand)) {
+    typeChecks({ 'scope': [params.scope, 'string']})
+  }
+  if (contains(['grant', 'revoke'], subcommand)) {
+    typeChecks({ 'team': [params.team, 'string']})
+  }
+  if (subcommand === 'grant') {
+    typeChecks({ 'permissions': [params.permissions, 'string']})
+    assert(params.permissions === 'read-only' ||
+           params.permissions === 'read-write',
+           'permissions must be either read-only or read-write')
+  }
+}
+
+function typeChecks (specs) {
+  Object.keys(specs).forEach(function (key) {
+    var checks = specs[key]
+    assert(typeof checks[0] === checks[1],
+           key + ' is required and must be of type ' + checks[1])
+  })
+}
+
+function contains (arr, item) {
+  return arr.indexOf(item) !== -1
+}
+
+function translatePermissions (perms) {
+  var newPerms = {}
+  for (var key in perms) {
+    if (perms.hasOwnProperty(key)) {
+      if (perms[key] === 'read') {
+        newPerms[key] = 'read-only'
+      } else if (perms[key] === 'write') {
+        newPerms[key] = 'read-write'
+      } else {
+        // This shouldn't happen, but let's not break things
+        // if the API starts returning different things.
+        newPerms[key] = perms[key]
+      }
+    }
+  }
+  return newPerms
 }

--- a/lib/team.js
+++ b/lib/team.js
@@ -1,0 +1,105 @@
+module.exports = team
+
+var assert = require('assert')
+var url = require('url')
+
+var subcommands = {}
+
+function team (sub, uri, params, cb) {
+  teamAssertions(sub, uri, params, cb)
+  return subcommands[sub].call(this, uri, params, cb)
+}
+
+subcommands.create = function (uri, params, cb) {
+  return this.request(apiUri(uri, 'org', params.scope, 'team'), {
+    method: 'PUT',
+    auth: params.auth,
+    body: JSON.stringify({
+      name: params.team
+    })
+  }, cb)
+}
+
+subcommands.destroy = function (uri, params, cb) {
+  return this.request(apiUri(uri, 'team', params.scope, params.team), {
+    method: 'DELETE',
+    auth: params.auth
+  }, cb)
+}
+
+subcommands.add = function (uri, params, cb) {
+  return this.request(apiUri(uri, 'team', params.scope, params.team, 'user'), {
+    method: 'PUT',
+    auth: params.auth,
+    body: JSON.stringify({
+      user: params.user
+    })
+  }, cb)
+}
+
+subcommands.rm = function (uri, params, cb) {
+  return this.request(apiUri(uri, 'team', params.scope, params.team, 'user'), {
+    method: 'DELETE',
+    auth: params.auth,
+    body: JSON.stringify({
+      user: params.user
+    })
+  }, cb)
+}
+
+subcommands.ls = function (uri, params, cb) {
+  var uriParams = '?format=cli'
+  if (params.team) {
+    var reqUri = apiUri(
+      uri, 'team', params.scope, params.team, 'user') + uriParams
+    return this.request(reqUri, {
+      method: 'GET',
+      auth: params.auth
+    }, cb)
+  } else {
+    return this.request(apiUri(uri, 'org', params.scope, 'team') + uriParams, {
+      method: 'GET',
+      auth: params.auth
+    }, cb)
+  }
+}
+
+// TODO - we punted this to v2
+// subcommands.edit = function (uri, params, cb) {
+//   return this.request(apiUri(uri, 'team', params.scope, params.team, 'user'), {
+//     method: 'POST',
+//     auth: params.auth,
+//     body: JSON.stringify({
+//       users: params.users
+//     })
+//   }, cb)
+// }
+
+function apiUri (registryUri) {
+  var path = Array.prototype.slice.call(arguments, 1)
+    .map(encodeURIComponent)
+    .join('/')
+  return url.resolve(registryUri, '-/' + path)
+}
+
+function teamAssertions (subcommand, uri, params, cb) {
+  assert(subcommand, 'subcommand is required')
+  assert(subcommands.hasOwnProperty(subcommand),
+         'team subcommand must be one of ' + Object.keys(subcommands))
+  assert(typeof uri === 'string', 'registry URI is required')
+  assert(typeof params === 'object', 'params are required')
+  assert(typeof params.auth === 'object', 'auth is required')
+  assert(typeof params.scope === 'string', 'scope is required')
+  assert(!cb || typeof cb === 'function', 'callback must be a function')
+  if (subcommand !== 'ls') {
+    assert(typeof params.team === 'string', 'team name is required')
+  }
+  if (subcommand === 'rm' || subcommand === 'add') {
+    assert(typeof params.user === 'string', 'user is required')
+  }
+  if (subcommand === 'edit') {
+    assert(typeof params.users === 'object' &&
+           params.users.length != null,
+           'users is required')
+  }
+}

--- a/test/access.js
+++ b/test/access.js
@@ -6,91 +6,292 @@ var client = common.freshClient()
 
 function nop () {}
 
-var URI = 'http://localhost:1337/-/package/underscore/access'
-var TOKEN = 'foo'
-var AUTH = {
-  token: TOKEN
-}
-var LEVEL = 'public'
+var URI = 'http://localhost:1337'
 var PARAMS = {
-  level: LEVEL,
-  auth: AUTH
+  auth: { token: 'foo' },
+  scope: 'myorg',
+  team: 'myteam',
+  package: '@foo/bar',
+  permissions: 'read-write'
 }
 
-test('access call contract', function (t) {
-  t.throws(function () {
-    client.access(undefined, AUTH, nop)
-  }, 'requires a URI')
+var commands = [
+  'public', 'restricted', 'grant', 'revoke', 'ls-packages', 'ls-collaborators'
+]
 
-  t.throws(function () {
-    client.access([], PARAMS, nop)
-  }, 'requires URI to be a string')
-
-  t.throws(function () {
-    client.access(URI, undefined, nop)
-  }, 'requires params object')
-
-  t.throws(function () {
-    client.access(URI, '', nop)
-  }, 'params must be object')
-
-  t.throws(function () {
-    client.access(URI, PARAMS, undefined)
-  }, 'requires callback')
-
-  t.throws(function () {
-    client.access(URI, PARAMS, 'callback')
-  }, 'callback must be function')
-
-  t.throws(
-    function () {
-      var params = {
-        auth: AUTH
-      }
-      client.access(URI, params, nop)
-    },
-    { name: 'AssertionError', message: 'must pass level to access' },
-    'access must include level'
-  )
-
-  t.throws(
-    function () {
-      var params = {
-        level: LEVEL
-      }
-      client.access(URI, params, nop)
-    },
-    { name: 'AssertionError', message: 'must pass auth to access' },
-    'access must include auth'
-  )
-
-  t.end()
+test('access public', function (t) {
+  server.expect('POST', '/-/package/%40foo%2Fbar/access', function (req, res) {
+    t.equal(req.method, 'POST')
+    onJsonReq(req, function (json) {
+      t.deepEqual(json, { access: 'public' })
+      res.statusCode = 200
+      res.json({ accessChanged: true })
+    })
+  })
+  var params = Object.create(PARAMS)
+  params.package = '@foo/bar'
+  client.access('public', URI, params, function (error, data) {
+    t.ifError(error, 'no errors')
+    t.ok(data.accessChanged, 'access level set')
+    t.end()
+  })
 })
 
-test('set access level on a package', function (t) {
-  server.expect('POST', '/-/package/underscore/access', function (req, res) {
+test('access restricted', function (t) {
+  server.expect('POST', '/-/package/%40foo%2Fbar/access', function (req, res) {
     t.equal(req.method, 'POST')
-
-    var b = ''
-    req.setEncoding('utf8')
-    req.on('data', function (d) {
-      b += d
+    onJsonReq(req, function (json) {
+      t.deepEqual(json, { access: 'restricted' })
+      res.statusCode = 200
+      res.json({ accessChanged: true })
     })
+  })
+  client.access('restricted', URI, PARAMS, function (error, data) {
+    t.ifError(error, 'no errors')
+    t.ok(data.accessChanged, 'access level set')
+    t.end()
+  })
+})
 
-    req.on('end', function () {
-      var updated = JSON.parse(b)
-
-      t.deepEqual(updated, { access: 'public' })
-
+test('access grant basic', function (t) {
+  server.expect('PUT', '/-/team/myorg/myteam/package', function (req, res) {
+    t.equal(req.method, 'PUT')
+    onJsonReq(req, function (json) {
+      t.deepEqual(json, {
+        permissions: PARAMS.permissions,
+        package: PARAMS.package
+      })
       res.statusCode = 201
       res.json({ accessChanged: true })
     })
   })
-
-  client.access(URI, PARAMS, function (error, data) {
+  client.access('grant', URI, PARAMS, function (error, data) {
     t.ifError(error, 'no errors')
     t.ok(data.accessChanged, 'access level set')
-
     t.end()
   })
 })
+
+test('access revoke basic', function (t) {
+  server.expect('DELETE', '/-/team/myorg/myteam/package', function (req, res) {
+    t.equal(req.method, 'DELETE')
+    onJsonReq(req, function (json) {
+      t.deepEqual(json, {
+        package: PARAMS.package
+      })
+      res.statusCode = 200
+      res.json({ accessChanged: true })
+    })
+  })
+  client.access('revoke', URI, PARAMS, function (error, data) {
+    t.ifError(error, 'no errors')
+    t.ok(data.accessChanged, 'access level set')
+    t.end()
+  })
+})
+
+test('ls-packages on team', function (t) {
+  var serverPackages = {
+    '@foo/bar': 'write',
+    '@foo/util': 'read'
+  }
+  var clientPackages = {
+    '@foo/bar': 'read-write',
+    '@foo/util': 'read-only'
+  }
+  var uri = '/-/team/myorg/myteam/package?format=cli'
+  server.expect('GET', uri, function (req, res) {
+    t.equal(req.method, 'GET')
+    res.statusCode = 200
+    res.json(serverPackages)
+  })
+  client.access('ls-packages', URI, PARAMS, function (error, data) {
+    t.ifError(error, 'no errors')
+    t.same(data, clientPackages)
+    t.end()
+  })
+})
+
+test('ls-packages on org', function (t) {
+  var serverPackages = {
+    '@foo/bar': 'write',
+    '@foo/util': 'read'
+  }
+  var clientPackages = {
+    '@foo/bar': 'read-write',
+    '@foo/util': 'read-only'
+  }
+  var uri = '/-/org/myorg/package?format=cli'
+  server.expect('GET', uri, function (req, res) {
+    t.equal(req.method, 'GET')
+    res.statusCode = 200
+    res.json(serverPackages)
+  })
+  var params = Object.create(PARAMS)
+  params.team = null
+  client.access('ls-packages', URI, params, function (error, data) {
+    t.ifError(error, 'no errors')
+    t.same(data, clientPackages)
+    t.end()
+  })
+})
+
+test('ls-packages on user', function (t) {
+  var serverPackages = {
+    '@foo/bar': 'write',
+    '@foo/util': 'read'
+  }
+  var clientPackages = {
+    '@foo/bar': 'read-write',
+    '@foo/util': 'read-only'
+  }
+  var firstUri = '/-/org/myorg/package?format=cli'
+  server.expect('GET', firstUri, function (req, res) {
+    t.equal(req.method, 'GET')
+    res.statusCode = 404
+    res.json({error: 'not found'})
+  })
+  var secondUri = '/-/user/myorg/package?format=cli'
+  server.expect('GET', secondUri, function (req, res) {
+    t.equal(req.method, 'GET')
+    res.statusCode = 200
+    res.json(serverPackages)
+  })
+  var params = Object.create(PARAMS)
+  params.team = null
+  client.access('ls-packages', URI, params, function (error, data) {
+    t.ifError(error, 'no errors')
+    t.same(data, clientPackages)
+    t.end()
+  })
+})
+
+test('ls-collaborators', function (t) {
+  var serverCollaborators = {
+    'myorg:myteam': 'write',
+    'myorg:anotherteam': 'read'
+  }
+  var clientCollaborators = {
+    'myorg:myteam': 'read-write',
+    'myorg:anotherteam': 'read-only'
+  }
+  var uri = '/-/package/%40foo%2Fbar/collaborators?format=cli'
+  server.expect('GET', uri, function (req, res) {
+    t.equal(req.method, 'GET')
+    res.statusCode = 200
+    res.json(serverCollaborators)
+  })
+  client.access('ls-collaborators', URI, PARAMS, function (error, data) {
+    t.ifError(error, 'no errors')
+    t.same(data, clientCollaborators)
+    t.end()
+  })
+})
+
+test('ls-collaborators w/ scope', function (t) {
+  var serverCollaborators = {
+    'myorg:myteam': 'write',
+    'myorg:anotherteam': 'read'
+  }
+  var clientCollaborators = {
+    'myorg:myteam': 'read-write',
+    'myorg:anotherteam': 'read-only'
+  }
+  var uri = '/-/package/%40foo%2Fbar/collaborators?format=cli&user=zkat'
+  server.expect('GET', uri, function (req, res) {
+    t.equal(req.method, 'GET')
+    res.statusCode = 200
+    res.json(serverCollaborators)
+  })
+  var params = Object.create(PARAMS)
+  params.user = 'zkat'
+  client.access('ls-collaborators', URI, params, function (error, data) {
+    t.ifError(error, 'no errors')
+    t.same(data, clientCollaborators)
+    t.end()
+  })
+})
+
+test('access command base validation', function (t) {
+  t.throws(function () {
+    client.access(undefined, URI, PARAMS, nop)
+  }, 'command is required')
+  t.throws(function () {
+    client.access('whoops', URI, PARAMS, nop)
+  }, 'command must be a valid subcommand')
+  commands.forEach(function (cmd) {
+    t.throws(function () {
+      client.access(cmd, undefined, PARAMS, nop)
+    }, 'registry URI is required')
+    t.throws(function () {
+      client.access(cmd, URI, undefined, nop)
+    }, 'params is required')
+    t.throws(function () {
+      client.access(cmd, URI, '', nop)
+    }, 'params must be an object')
+    t.throws(function () {
+      client.access(cmd, URI, {scope: 'o', team: 't'}, nop)
+    }, 'auth is required')
+    t.throws(function () {
+      client.access(cmd, URI, {auth: 5, scope: 'o', team: 't'}, nop)
+    }, 'auth must be an object')
+    t.throws(function () {
+      client.access(cmd, URI, PARAMS, {})
+    }, 'callback must be a function')
+    t.throws(function () {
+      client.access(cmd, URI, PARAMS, undefined)
+    }, 'callback is required')
+    if (contains([
+      'public', 'restricted', 'grant', 'revoke', 'ls-collaborators'
+    ], cmd)) {
+      t.throws(function () {
+        var params = Object.create(PARAMS)
+        params.package = null
+        client.access(cmd, URI, params, nop)
+      }, 'package is required')
+      t.throws(function () {
+        var params = Object.create(PARAMS)
+        params.package = 'underscore'
+        client.access(cmd, URI, params, nop)
+      }, 'only scopes packages are allowed')
+    }
+    if (contains(['grant', 'revoke', 'ls-packages'], cmd)) {
+      t.throws(function () {
+        var params = Object.create(PARAMS)
+        params.scope = null
+        client.access(cmd, URI, params, nop)
+      }, 'scope is required')
+    }
+    if (contains(['grant', 'revoke'], cmd)) {
+      t.throws(function () {
+        var params = Object.create(PARAMS)
+        params.team = null
+        client.access(cmd, URI, params, nop)
+      }, 'team is required')
+    }
+    if (cmd === 'grant') {
+      t.throws(function () {
+        var params = Object.create(PARAMS)
+        params.permissions = null
+        client.access(cmd, URI, params, nop)
+      }, 'permissions are required')
+      t.throws(function () {
+        var params = Object.create(PARAMS)
+        params.permissions = 'idkwhat'
+        client.access(cmd, URI, params, nop)
+      }, 'permissions must be either read-only or read-write')
+    }
+  })
+  t.end()
+})
+
+function onJsonReq (req, cb) {
+  var buffer = ''
+  req.setEncoding('utf8')
+  req.on('data', function (data) { buffer += data })
+  req.on('end', function () { cb(buffer ? JSON.parse(buffer) : undefined) })
+}
+
+function contains (arr, item) {
+  return arr.indexOf(item) !== -1
+}

--- a/test/team.js
+++ b/test/team.js
@@ -1,0 +1,210 @@
+var test = require('tap').test
+
+var server = require('./lib/server.js')
+var common = require('./lib/common.js')
+var client = common.freshClient()
+
+function nop () {}
+
+var URI = 'http://localhost:1337'
+var PARAMS = {
+  auth: {
+    token: 'foo'
+  },
+  scope: 'myorg',
+  team: 'myteam'
+}
+
+var commands = ['create', 'destroy', 'add', 'rm', 'ls']
+
+test('team create basic', function (t) {
+  var teamData = {
+    name: PARAMS.team,
+    scope_id: 1234,
+    created: '2015-07-23T18:07:49.959Z',
+    updated: '2015-07-23T18:07:49.959Z',
+    deleted: null
+  }
+  server.expect('PUT', '/-/org/myorg/team', function (req, res) {
+    t.equal(req.method, 'PUT')
+    onJsonReq(req, function (json) {
+      t.same(json, { name: PARAMS.team })
+      res.statusCode = 200
+      res.json(teamData)
+    })
+  })
+  client.team('create', URI, PARAMS, function (err, data) {
+    t.ifError(err, 'no errors')
+    t.same(data, teamData)
+    t.end()
+  })
+})
+
+test('team destroy', function (t) {
+  var teamData = {
+    name: 'myteam',
+    scope_id: 1234,
+    created: '2015-07-23T18:07:49.959Z',
+    updated: '2015-07-23T18:07:49.959Z',
+    deleted: '2015-07-23T18:27:27.178Z'
+  }
+  server.expect('DELETE', '/-/team/myorg/myteam', function (req, res) {
+    t.equal(req.method, 'DELETE')
+    onJsonReq(req, function (json) {
+      t.same(json, undefined)
+      res.statusCode = 200
+      res.json(teamData)
+    })
+  })
+  client.team('destroy', URI, PARAMS, function (err, data) {
+    t.ifError(err, 'no errors')
+    t.same(data, teamData)
+    t.end()
+  })
+})
+
+test('team add basic', function (t) {
+  var params = Object.create(PARAMS)
+  params.user = 'zkat'
+  server.expect('PUT', '/-/team/myorg/myteam/user', function (req, res) {
+    t.equal(req.method, 'PUT')
+    onJsonReq(req, function (json) {
+      t.same(json, { user: params.user })
+      res.statusCode = 200
+      res.json(undefined)
+    })
+  })
+  client.team('add', URI, params, function (err, data) {
+    t.ifError(err, 'no errors')
+    t.same(data, undefined)
+    t.end()
+  })
+})
+
+test('team add user not in org', function (t) {
+  var params = Object.create(PARAMS)
+  params.user = 'zkat'
+  var errMsg = 'user is already in team'
+  server.expect('PUT', '/-/team/myorg/myteam/user', function (req, res) {
+    t.equal(req.method, 'PUT')
+    res.statusCode = 400
+    res.json({
+      error: errMsg
+    })
+  })
+  client.team('add', URI, params, function (err, data) {
+    t.equal(err.message, errMsg + ' : ' + '-/team/myorg/myteam/user')
+    t.same(data, {error: errMsg})
+    t.end()
+  })
+})
+
+test('team rm basic', function (t) {
+  var params = Object.create(PARAMS)
+  params.user = 'bcoe'
+  server.expect('DELETE', '/-/team/myorg/myteam/user', function (req, res) {
+    t.equal(req.method, 'DELETE')
+    onJsonReq(req, function (json) {
+      t.same(json, params)
+      res.statusCode = 200
+      res.json(undefined)
+    })
+  })
+  client.team('rm', URI, params, function (err, data) {
+    t.ifError(err, 'no errors')
+    t.same(data, undefined)
+    t.end()
+  })
+})
+
+test('team ls (on org)', function (t) {
+  var params = Object.create(PARAMS)
+  params.team = null
+  var teams = ['myorg:team1', 'myorg:team2', 'myorg:team3']
+  server.expect('GET', '/-/org/myorg/team?format=cli', function (req, res) {
+    t.equal(req.method, 'GET')
+    onJsonReq(req, function (json) {
+      t.same(json, undefined)
+      res.statusCode = 200
+      res.json(teams)
+    })
+  })
+  client.team('ls', URI, params, function (err, data) {
+    t.ifError(err, 'no errors')
+    t.same(data, teams)
+    t.end()
+  })
+})
+
+test('team ls (on team)', function (t) {
+  var uri = '/-/team/myorg/myteam/user?format=cli'
+  var users = ['zkat', 'bcoe']
+  server.expect('GET', uri, function (req, res) {
+    t.equal(req.method, 'GET')
+    onJsonReq(req, function (json) {
+      t.same(json, undefined)
+      res.statusCode = 200
+      res.json(users)
+    })
+  })
+  client.team('ls', URI, PARAMS, function (err, data) {
+    t.ifError(err, 'no errors')
+    t.same(data, users)
+    t.end()
+  })
+})
+
+// test('team edit', function (t) {
+//   server.expect('PUT', '/-/org/myorg/team', function (req, res) {
+//     t.equal(req.method, 'PUT')
+//     res.statusCode = 201
+//     res.json({})
+//   })
+//   client.team('create', URI, PARAMS, function (err, data) {
+//     t.ifError(err, 'no errors')
+//     t.end()
+//   })
+// })
+
+test('team command base validation', function (t) {
+  t.throws(function () {
+    client.team(undefined, URI, PARAMS, nop)
+  }, 'command is required')
+  commands.forEach(function (cmd) {
+    t.throws(function () {
+      client.team(cmd, undefined, PARAMS, nop)
+    }, 'registry URI is required')
+    t.throws(function () {
+      client.team(cmd, URI, undefined, nop)
+    }, 'params is required')
+    t.throws(function () {
+      client.team(cmd, URI, {scope: 'o', team: 't'}, nop)
+    }, 'auth is required')
+    t.throws(function () {
+      client.team(cmd, URI, {auth: {token: 'f'}, team: 't'}, nop)
+    }, 'scope is required')
+    t.throws(function () {
+      client.team(cmd, URI, PARAMS, {})
+    }, 'callback must be a function')
+    if (cmd !== 'ls') {
+      t.throws(function () {
+        client.team(
+          cmd, URI, {auth: {token: 'f'}, scope: 'o'}, nop)
+      }, 'team name is required')
+    }
+    if (cmd === 'add' || cmd === 'rm') {
+      t.throws(function () {
+        client.team(
+          cmd, URI, PARAMS, nop)
+      }, 'user is required')
+    }
+  })
+  t.end()
+})
+
+function onJsonReq (req, cb) {
+  var buffer = ''
+  req.setEncoding('utf8')
+  req.on('data', function (data) { buffer += data })
+  req.on('end', function () { cb(buffer ? JSON.parse(buffer) : undefined) })
+}


### PR DESCRIPTION
This implements the npm-registry-client side of `npm access` and `npm test` outlined in our internal spec. Specifics are subject to change, but this lays out the main architecture (which I'd still like to work on -- though I don't think we can do better than this without rearchitecting the whole library).

Most notable is that I rewrote `lib/access.js` in such a way that it won't be backwards-compatible, but the APIs and checks and stuff should be mostly the same. This patch will warrant a semver major bump.