### PR TITLE
deprecate: fix scoped package support

### DIFF
--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -38,6 +38,6 @@ function deprecate (uri, params, cb) {
       body: data,
       auth: auth
     }
-    this.request(url.resolve(uri, data._id), options, cb)
+    this.request(uri, options, cb)
   }.bind(this))
 }

--- a/test/deprecate.js
+++ b/test/deprecate.js
@@ -154,3 +154,57 @@ test('deprecate a package', function (t) {
     }
   )
 })
+
+test('deprecate a scoped package', function (t) {
+  server.expect('GET', '/@test%2funderscore?write=true', function (req, res) {
+    t.equal(req.method, 'GET')
+
+    res.json(cache)
+  })
+
+  server.expect('PUT', '/@test%2funderscore', function (req, res) {
+    t.equal(req.method, 'PUT')
+
+    var b = ''
+    req.setEncoding('utf8')
+    req.on('data', function (d) {
+      b += d
+    })
+
+    req.on('end', function () {
+      var updated = JSON.parse(b)
+
+      var undeprecated = [
+        '1.0.3', '1.0.4', '1.1.0', '1.1.1', '1.1.2', '1.1.3', '1.1.4', '1.1.5', '1.1.6',
+        '1.1.7', '1.2.0', '1.2.1', '1.2.2', '1.2.3', '1.2.4', '1.3.0', '1.3.1', '1.3.3'
+      ]
+      for (var i = 0; i < undeprecated.length; i++) {
+        var current = undeprecated[i]
+        t.notEqual(
+          updated.versions[current].deprecated,
+          MESSAGE,
+          current + ' not deprecated'
+        )
+      }
+
+      t.equal(
+        updated.versions[VERSION].deprecated,
+        MESSAGE,
+        VERSION + ' deprecated'
+      )
+      res.statusCode = 201
+      res.json({ deprecated: true })
+    })
+  })
+
+  client.deprecate(
+    common.registry + '/@test%2funderscore',
+    PARAMS,
+    function (er, data) {
+      t.ifError(er)
+      t.ok(data.deprecated, 'was deprecated')
+
+      t.end()
+    }
+  )
+})


### PR DESCRIPTION
I'm pretty sure deprecating scoped packages never really worked. This is a copy-paste of the unscoped package test + a simple fix that seems to cover it. I got the impression from reading the git logs that the `url.resolve` was only really there for historical reasons.