### PR TITLE
Add SSL params to request

### DIFF
--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -1,7 +1,6 @@
 module.exports = deprecate
 
 var assert = require('assert')
-var url = require('url')
 var semver = require('semver')
 
 function deprecate (uri, params, cb) {

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -82,7 +82,8 @@ function makeRequest (remote, params, cb) {
     parsed,
     'GET',
     'application/x-tar, application/vnd.github+json; q=0.1',
-    headers
+    headers,
+    params
   )
   // always want to follow redirects for fetch
   opts.followRedirect = true

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -1,3 +1,4 @@
+var assign = require('lodash.assign')
 var crypto = require('crypto')
 var HttpAgent = require('http').Agent
 var HttpsAgent = require('https').Agent
@@ -5,41 +6,43 @@ var HttpsAgent = require('https').Agent
 var pkg = require('../package.json')
 
 var httpAgent
-var httpsAgent
+var httpsAgents = {}
 
 module.exports = initialize
 
-function initialize (uri, method, accept, headers) {
-  if (!this.config.sessionToken) {
-    this.config.sessionToken = crypto.randomBytes(8).toString('hex')
-    this.log.verbose('request id', this.config.sessionToken)
+function initialize (uri, method, accept, headers, params) {
+  params = assign({}, this.config, params)
+
+  if (!params.sessionToken) {
+    params.sessionToken = crypto.randomBytes(8).toString('hex')
+    this.log.verbose('request id', params.sessionToken)
   }
 
   var opts = {
     url: uri,
     method: method,
     headers: headers,
-    localAddress: this.config.proxy.localAddress,
-    strictSSL: this.config.ssl.strict,
-    cert: this.config.ssl.certificate,
-    key: this.config.ssl.key,
-    ca: this.config.ssl.ca,
-    agent: getAgent(uri.protocol, this.config)
+    localAddress: params.proxy.localAddress,
+    strictSSL: params.ssl.strict,
+    cert: params.ssl.certificate,
+    key: params.ssl.key,
+    ca: params.ssl.ca,
+    agent: getAgent(uri.protocol, params)
   }
 
   // allow explicit disabling of proxy in environment via CLI
   //
   // how false gets here is the CLI's problem (it's gross)
-  if (this.config.proxy.http === false) {
+  if (params.proxy.http === false) {
     opts.proxy = null
   } else {
     // request will not pay attention to the NOPROXY environment variable if a
     // config value named proxy is passed in, even if it's set to null.
     var proxy
     if (uri.protocol === 'https:') {
-      proxy = this.config.proxy.https
+      proxy = params.proxy.https
     } else {
-      proxy = this.config.proxy.http
+      proxy = params.proxy.http
     }
     if (typeof proxy === 'string') opts.proxy = proxy
   }
@@ -49,22 +52,25 @@ function initialize (uri, method, accept, headers) {
 
   if (this.refer) headers.referer = this.refer
 
-  headers['npm-session'] = this.config.sessionToken
-  headers['user-agent'] = this.config.userAgent
+  headers['npm-session'] = params.sessionToken
+  headers['user-agent'] = params.userAgent
 
   return opts
 }
 
-function getAgent (protocol, config) {
+function getAgent (protocol, params) {
   if (protocol === 'https:') {
+    var key = JSON.stringify(params.ssl)
+    var httpsAgent = httpsAgents[key]
+
     if (!httpsAgent) {
-      httpsAgent = new HttpsAgent({
+      httpsAgent = httpsAgents[key] = new HttpsAgent({
         keepAlive: true,
-        localAddress: config.proxy.localAddress,
-        rejectUnauthorized: config.ssl.strict,
-        ca: config.ssl.ca,
-        cert: config.ssl.certificate,
-        key: config.ssl.key
+        localAddress: params.proxy.localAddress,
+        rejectUnauthorized: params.ssl.strict,
+        ca: params.ssl.ca,
+        cert: params.ssl.certificate,
+        key: params.ssl.key
       })
     }
 
@@ -73,7 +79,7 @@ function getAgent (protocol, config) {
     if (!httpAgent) {
       httpAgent = new HttpAgent({
         keepAlive: true,
-        localAddress: config.proxy.localAddress
+        localAddress: params.proxy.localAddress
       })
     }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -106,7 +106,8 @@ function makeRequest (uri, params, cb_) {
     parsed,
     params.method,
     'application/json',
-    headers
+    headers,
+    params
   )
 
   opts.followRedirect = (typeof params.follow === 'boolean' ? params.follow : true)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chownr": "^1.0.1",
     "concat-stream": "^1.4.6",
     "graceful-fs": "^3.0.0",
+    "lodash.assign": "^3.2.0",
     "mkdirp": "^0.5.0",
     "normalize-package-data": "~1.0.1 || ^2.0.0",
     "npm-package-arg": "^3.0.0 || ^4.0.0",


### PR DESCRIPTION
This change adds the the option to define (mainly) SSL parameters in fetch/request. This allows, for instance, npm to use different SSL certificates per scope/registry.

There will be one `HttpsAgent` for each SSL configuration.
