### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "chownr": "^1.0.1",
     "concat-stream": "^1.4.6",
-    "graceful-fs": "^3.0.0",
+    "graceful-fs": "^4.1.2",
     "mkdirp": "^0.5.0",
     "normalize-package-data": "~1.0.1 || ^2.0.0",
     "npm-package-arg": "^3.0.0 || ^4.0.0",


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714