### PR TITLE
fixed npm-notice functionality so that we can send messages from server to client

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -64,6 +64,13 @@ function regRequest (uri, params, cb_) {
   var self = this
   this.attempt(function (operation) {
     makeRequest.call(self, uri, params, function (er, parsed, raw, response) {
+      if (response) {
+        self.log.verbose('headers', response.headers)
+        if (response.headers['npm-notice']) {
+          self.log.warn('notice', response.headers['npm-notice'])
+        }
+      }
+
       if (!er || (er.message && er.message.match(/^SSL Error/))) {
         if (er) er.code = 'ESSL'
         return cb(er, parsed, raw, response)
@@ -78,12 +85,6 @@ function regRequest (uri, params, cb_) {
       if (er && statusRetry && operation.retry(er)) {
         self.log.info('retry', 'will retry, error on last attempt: ' + er)
         return undefined
-      }
-      if (response) {
-        self.log.verbose('headers', response.headers)
-        if (response.headers['npm-notice']) {
-          self.log.warn('notice', response.headers['npm-notice'])
-        }
       }
       cb.apply(null, arguments)
     })

--- a/test/request.js
+++ b/test/request.js
@@ -277,6 +277,40 @@ test('run request through its paces', function (t) {
   })
 })
 
+test('outputs notice if npm-notice header is set', function (t) {
+  var client = common.freshClient({
+    log: {
+      error: noop,
+      warn: function (prefix, msg) {
+        warnings.push(msg)
+      },
+      info: noop,
+      verbose: noop,
+      silly: noop,
+      http: noop,
+      pause: noop,
+      resume: noop
+    }
+  })
+  var message = 'notice me!'
+  var warnings = []
+
+  function noop () {}
+
+  server.expect('GET', '/npm-notice', function (req, res) {
+    req.pipe(concat(function () {
+      res.statusCode = 200
+      res.setHeader('npm-notice', message)
+      res.end()
+    }))
+  })
+
+  client.request(common.registry + '/npm-notice', {}, function (er) {
+    t.notEqual(warnings.indexOf(message), -1, 'notice not printed')
+    t.end()
+  })
+})
+
 test('cleanup', function (t) {
   server.close()
   t.end()


### PR DESCRIPTION
It's expected that you can set the `npm-notice` header on the server-side and that the client will, in turn, output the message to the client.

The logic for outputting this message was, unfortunately, below the logic that returns early:

```js
      if (!er || (er.message && er.message.match(/^SSL Error/))) {
        if (er) er.code = 'ESSL'
        return cb(er, parsed, raw, response)
      }
```

I've fixed this by moving the logic up, and adding a test.