### PR TITLE
Add timeout option (with default) for network requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,4 @@ any):
   [couch-login](https://npmjs.org/package/couch-login).
 * `sessionToken` {string} A random identifier for this set of client requests.
   Default = 8 random hexadecimal bytes.
+* `timeout` {Number} Number of milliseconds for request timeout. Passed into request library.

--- a/README.md
+++ b/README.md
@@ -312,4 +312,4 @@ any):
   [couch-login](https://npmjs.org/package/couch-login).
 * `sessionToken` {string} A random identifier for this set of client requests.
   Default = 8 random hexadecimal bytes.
-* `timeout` {Number} Number of milliseconds for request timeout. Passed into request library.
+* `timeout` {Number} Number of milliseconds for request timeout. Passed into request library. Default = 10000 (10 seconds)

--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ function RegClient (config) {
     this.config.proxy.https = this.config.proxy.http
   }
 
+  if (typeof this.config.timeout !== 'number') this.config.timeout = 10000
+
   this.config.ssl = this.config.ssl || {}
   if (this.config.ssl.strict === undefined) this.config.ssl.strict = true
 

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -24,6 +24,7 @@ function initialize (uri, method, accept, headers) {
     cert: this.config.ssl.certificate,
     key: this.config.ssl.key,
     ca: this.config.ssl.ca,
+    timeout: this.config.timeout,
     agent: getAgent(uri.protocol, this.config)
   }
 

--- a/test/fetch-client-timeout.js
+++ b/test/fetch-client-timeout.js
@@ -1,0 +1,36 @@
+var tap = require('tap')
+
+var server = require('./lib/server.js')
+var common = require('./lib/common.js')
+
+tap.test('fetch with a 404 response', function (t) {
+  server.expect('/anything', function (req, res) {
+    t.equal(req.method, 'GET', 'got expected method')
+  })
+  server.expect('/anything', function (req, res) {
+    t.equal(req.method, 'GET', 'got expected method')
+  })
+
+  var client = common.freshClient({
+    timeout: 100,
+    retry: {
+      retries: 1,
+      minTimeout: 10,
+      maxTimeout: 100
+    }
+  })
+  var defaulted = {}
+  client.fetch(
+    'http://localhost:1337/anything',
+    defaulted,
+    function (err, res) {
+      t.equal(
+        err.message,
+        'ETIMEDOUT',
+        'got expected error message'
+      )
+      server.close()
+      t.end()
+    }
+  )
+})

--- a/test/fetch-client-timeout.js
+++ b/test/fetch-client-timeout.js
@@ -12,7 +12,7 @@ tap.test('fetch with a 404 response', function (t) {
   })
 
   var client = common.freshClient({
-    timeout: 100,
+    timeout: 25,
     retry: {
       retries: 1,
       minTimeout: 10,

--- a/test/request-client-timeout.js
+++ b/test/request-client-timeout.js
@@ -12,7 +12,7 @@ tap.test('fetch with a 404 response', function (t) {
   })
 
   var client = common.freshClient({
-    timeout: 100,
+    timeout: 25,
     retry: {
       retries: 1,
       minTimeout: 10,

--- a/test/request-client-timeout.js
+++ b/test/request-client-timeout.js
@@ -1,0 +1,36 @@
+var tap = require('tap')
+
+var server = require('./lib/server.js')
+var common = require('./lib/common.js')
+
+tap.test('fetch with a 404 response', function (t) {
+  server.expect('/anything', function (req, res) {
+    t.equal(req.method, 'GET', 'got expected method')
+  })
+  server.expect('/anything', function (req, res) {
+    t.equal(req.method, 'GET', 'got expected method')
+  })
+
+  var client = common.freshClient({
+    timeout: 100,
+    retry: {
+      retries: 1,
+      minTimeout: 10,
+      maxTimeout: 100
+    }
+  })
+  var defaulted = {}
+  client.request(
+    'http://localhost:1337/anything',
+    defaulted,
+    function (err, res) {
+      t.equal(
+        err.message,
+        'ETIMEDOUT',
+        'got expected error message'
+      )
+      server.close()
+      t.end()
+    }
+  )
+})


### PR DESCRIPTION
Since the request library does not set a default timeout, any request that hangs will hang indefinitely and cause `npm install` to hang indefinitely. The request library recommends having a timeout on all requests. This diff adds a timeout option that defaults to 10 seconds, as well as tests surrounding the timeout functionality.
