### PR TITLE
 Report in http header if we're in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,3 +318,8 @@ any):
   origin (unique combination of protocol:host:port). Passed to the
   [httpAgent](https://nodejs.org/api/http.html#http_agent_maxsockets).
   Default = 50
+* `isFromCI` {Boolean} Identify to severs if this request is coming from CI (for statistics purposes).
+  Default = detected from environment– primarily this is done by looking for
+  the CI environment variable to be set to `true`.  Also accepted are the
+  existence of the `JENKINS_URL`, `bamboo.buildKey` and `TDDIUM` environment
+  variables.

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -11,6 +11,11 @@ function initialize (uri, method, accept, headers) {
     this.config.sessionToken = crypto.randomBytes(8).toString('hex')
     this.log.verbose('request id', this.config.sessionToken)
   }
+  if (this.config.isFromCI == null) {
+    this.config.isFromCI = Boolean(
+      process.env['CI'] === 'true' || process.env['TDDIUM'] ||
+      process.env['JENKINS_URL'] || process.env['bamboo.buildKey'])
+  }
 
   var opts = {
     url: uri,
@@ -47,6 +52,7 @@ function initialize (uri, method, accept, headers) {
   if (this.refer) headers.referer = this.refer
 
   headers['npm-session'] = this.config.sessionToken
+  headers['npm-in-ci'] = String(this.config.isFromCI)
   headers['user-agent'] = this.config.userAgent
 
   return opts

--- a/test/config-override.js
+++ b/test/config-override.js
@@ -24,7 +24,8 @@ var config = {
   log: { fake: function () {} },
   defaultTag: 'next',
   couchToken: { object: true },
-  sessionToken: 'hamchunx'
+  sessionToken: 'hamchunx',
+  isFromCI: true
 }
 
 test('config defaults', function (t) {
@@ -52,6 +53,7 @@ test('config defaults', function (t) {
   t.equal(client.config.defaultTag, 'next')
   t.ok(client.config.couchToken.object)
   t.equal(client.config.sessionToken, 'hamchunx')
+  t.ok(client.config.isFromCI)
 
   t.end()
 })


### PR DESCRIPTION
Per a lunch conversation with @ceejbot, this adds an `npm-in-ci` header to requests that is `true` or `false` based on the following environment checks:

`CI`="true": Travis, CircleCI, Gitlab CI, Snap CI, Codeship, semaphore, drone.io, Buildkite, PlatformIO
`JENKINS_URL` is set: Jenkins
`bamboo.buildKey` is set: Bamboo
`TDDIUM` is set: Solano
