### PR TITLE
Limit maxSockets for client connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,5 +310,9 @@ any):
   Default = `"latest"`
 * `couchToken` {Object} A token for use with
   [couch-login](https://npmjs.org/package/couch-login).
-* `sessionToken` {string} A random identifier for this set of client requests.
+* `sessionToken` {String} A random identifier for this set of client requests.
   Default = 8 random hexadecimal bytes.
+* `maxSockets` {Number} The maximum number of connections that will be open per
+  origin (unique combination of protocol:host:port). Passed to the
+  [httpAgent](https://nodejs.org/api/http.html#http_agent_maxsockets).
+  Default = 50

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function RegClient (config) {
   if (typeof this.config.retry.factor !== 'number') this.config.retry.factor = 10
   if (typeof this.config.retry.minTimeout !== 'number') this.config.retry.minTimeout = 10000
   if (typeof this.config.retry.maxTimeout !== 'number') this.config.retry.maxTimeout = 60000
+  if (typeof this.config.maxSockets !== 'number') this.config.maxSockets = 50
 
   this.config.userAgent = this.config.userAgent || 'node/' + process.version
   this.config.defaultTag = this.config.defaultTag || 'latest'

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -4,9 +4,6 @@ var HttpsAgent = require('https').Agent
 
 var pkg = require('../package.json')
 
-var httpAgent
-var httpsAgent
-
 module.exports = initialize
 
 function initialize (uri, method, accept, headers) {
@@ -24,7 +21,7 @@ function initialize (uri, method, accept, headers) {
     cert: this.config.ssl.certificate,
     key: this.config.ssl.key,
     ca: this.config.ssl.ca,
-    agent: getAgent(uri.protocol, this.config)
+    agent: getAgent.call(this, uri.protocol)
   }
 
   // allow explicit disabling of proxy in environment via CLI
@@ -55,28 +52,30 @@ function initialize (uri, method, accept, headers) {
   return opts
 }
 
-function getAgent (protocol, config) {
+function getAgent (protocol) {
   if (protocol === 'https:') {
-    if (!httpsAgent) {
-      httpsAgent = new HttpsAgent({
+    if (!this.httpsAgent) {
+      this.httpsAgent = new HttpsAgent({
         keepAlive: true,
-        localAddress: config.proxy.localAddress,
-        rejectUnauthorized: config.ssl.strict,
-        ca: config.ssl.ca,
-        cert: config.ssl.certificate,
-        key: config.ssl.key
+        maxSockets: this.config.maxSockets,
+        localAddress: this.config.proxy.localAddress,
+        rejectUnauthorized: this.config.ssl.strict,
+        ca: this.config.ssl.ca,
+        cert: this.config.ssl.certificate,
+        key: this.config.ssl.key
       })
     }
 
-    return httpsAgent
+    return this.httpsAgent
   } else {
-    if (!httpAgent) {
-      httpAgent = new HttpAgent({
+    if (!this.httpAgent) {
+      this.httpAgent = new HttpAgent({
         keepAlive: true,
-        localAddress: config.proxy.localAddress
+        maxSockets: this.config.maxSockets,
+        localAddress: this.config.proxy.localAddress
       })
     }
 
-    return httpAgent
+    return this.httpAgent
   }
 }

--- a/test/initialize.js
+++ b/test/initialize.js
@@ -1,4 +1,5 @@
 var test = require('tap').test
+var url = require('url')
 
 // var server = require('./lib/server.js')
 var Client = require('../')
@@ -29,6 +30,39 @@ test('defaulted initialization', function (t) {
 
   var HttpAgent = require('http').Agent
   t.ok(options.agent instanceof HttpAgent, 'got an HTTP agent for an HTTP URL')
+  t.equal(options.agent.maxSockets, 50, 'maxSockets set to a reasonable default')
+
+  t.end()
+})
+
+test('intializing with maxSockets set works for http', function (t) {
+  var client = new Client({ maxSockets: Infinity })
+  var options = client.initialize(
+    url.parse('http://localhost:1337/'),
+    'GET',
+    'application/json',
+    {}
+  )
+
+  var HttpAgent = require('http').Agent
+  t.ok(options.agent instanceof HttpAgent, 'got an HTTP agent for an HTTP URL')
+  t.equal(options.agent.maxSockets, Infinity, 'request uses configured value for maxSockets')
+
+  t.end()
+})
+
+test('intializing with maxSockets set works for https', function (t) {
+  var client = new Client({ maxSockets: Infinity })
+  var options = client.initialize(
+    url.parse('https://localhost:1337/'),
+    'GET',
+    'application/json',
+    {}
+  )
+
+  var HttpsAgent = require('https').Agent
+  t.ok(options.agent instanceof HttpsAgent, 'got an HTTPS agent for an HTTPS URL')
+  t.equal(options.agent.maxSockets, Infinity, 'request uses configured value for maxSockets')
 
   t.end()
 })


### PR DESCRIPTION
NPM installs are failing all the time for installs of large shrinkwrapped projects on my home (wifi) network. It tends to work on a wired network. I figured out that this was due to the large number of connections that npm makes to the registry. Inflating a shrinkwrap results in a request being made to the registry for each item in the dependency tree - and because of npm3's flat file structure, almost all of them happen at once.

This PR makes use of ~~[request](https://github.com/request/request)'s `pool` option, along with~~ the agent's `maxSockets` option to use client connection pooling which drastically reduces the number of outgoing connections, resulting in a quicker and more stable install.

It looks like this should fix some issues people are having with installing lots of dependencies over consumer network hardware / crappy internet connections / environments with limited resources.