### PR TITLE
defer gzip handling to `request`

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -7,7 +7,6 @@ module.exports = regRequest
 //
 var assert = require('assert')
 var url = require('url')
-var zlib = require('zlib')
 var Stream = require('stream').Stream
 var STATUS_CODES = require('http').STATUS_CODES
 
@@ -97,9 +96,6 @@ function makeRequest (uri, params, cb_) {
   var parsed = url.parse(uri)
   var headers = {}
 
-  // metadata should be compressed
-  headers['accept-encoding'] = 'gzip'
-
   var er = this.authify(params.authed, parsed, headers, params.auth)
   if (er) return cb_(er)
 
@@ -112,6 +108,9 @@ function makeRequest (uri, params, cb_) {
 
   opts.followRedirect = (typeof params.follow === 'boolean' ? params.follow : true)
   opts.encoding = null // tell request let body be Buffer instance
+
+  // metadata should be compressed
+  opts.gzip = true
 
   if (params.etag) {
     this.log.verbose('etag', params.etag)
@@ -168,15 +167,7 @@ function decodeResponseBody (cb) {
       response.socket.destroy()
     }
 
-    if (response.headers['content-encoding'] !== 'gzip') {
-      return cb(er, response, data)
-    }
-
-    zlib.gunzip(data, function (er, buf) {
-      if (er) return cb(er, response, data)
-
-      cb(null, response, buf)
-    })
+    return cb(er, response, data)
   }
 }
 


### PR DESCRIPTION
* if not supported, no GZIP is returned. All is well
* If supported, GZIP is returned but handled entirely by request and we get smaller payloads.