### PR TITLE
Add Ability to use url based authentication for registries

### DIFF
--- a/lib/authify.js
+++ b/lib/authify.js
@@ -13,6 +13,8 @@ function authify (authed, parsed, headers, credentials) {
       var username = encodeURIComponent(credentials.username)
       var password = encodeURIComponent(credentials.password)
       parsed.auth = username + ':' + password
+    } else if (parsed.auth) {
+      this.log.info('request', 'using auth from uri')
     } else {
       return new Error(
         'This request requires auth credentials. Run `npm login` and repeat the request.'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "name": "npm-registry-client",
   "description": "Client for the npm registry",
-  "version": "7.1.1",
+  "version": "7.1.0",
   "repository": {
     "url": "https://github.com/npm/npm-registry-client.git"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "name": "npm-registry-client",
   "description": "Client for the npm registry",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "repository": {
     "url": "https://github.com/npm/npm-registry-client.git"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "name": "npm-registry-client",
   "description": "Client for the npm registry",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "repository": {
     "url": "https://github.com/npm/npm-registry-client.git"
   },

--- a/test/authify.js
+++ b/test/authify.js
@@ -1,0 +1,50 @@
+var test = require('tap').test
+var url = require('url')
+
+require('./lib/server.js').close()
+var common = require('./lib/common.js')
+
+test('authify uses token if supplied', function (t) {
+  var client = common.freshClient({})
+  var parsed = url.parse('http://localhost/npm/test')
+  var headers = {}
+  var auth = { token: 'mytoken' }
+  var result = client.authify(true, parsed, headers, auth)
+  t.equals(result, null)
+  t.equals(headers.authorization, 'Bearer mytoken')
+  t.end()
+})
+
+test('authify uses username and password if supplied in credentials', function (t) {
+  var client = common.freshClient({})
+  var parsed = url.parse('http://localhost/npm/test')
+  var headers = {}
+  var auth = { username: 'username', password: 'password' }
+  var result = client.authify(true, parsed, headers, auth)
+  t.equals(result, undefined)
+  t.same(headers, {})
+  t.equals(parsed.auth, 'username:password')
+  t.end()
+})
+
+test('authify uses username and password in uri if not supplied in credentials', function (t) {
+  var client = common.freshClient({})
+  var parsed = url.parse('http://uri:uripassword@localhost/npm/test')
+  var headers = {}
+  var auth = { }
+  var result = client.authify(true, parsed, headers, auth)
+  t.equals(result, undefined)
+  t.same(headers, {})
+  t.equals(parsed.auth, 'uri:uripassword')
+  t.end()
+})
+
+test('authify returns error if neither uri or credentials have username / password', function (t) {
+  var client = common.freshClient({})
+  var parsed = url.parse('http://localhost/npm/test')
+  var headers = {}
+  var auth = {}
+  var result = client.authify(true, parsed, headers, auth)
+  t.type(result, 'Error')
+  t.end()
+})


### PR DESCRIPTION
It is easier in some cases not to have to manually login to a private npm server with `npm adduser` instead use the standard http uri auth format `protocol://username:password@url` 

The change is a simple addition to the authify to allow the auth parameters of the parsed uri to pass through to the request.

Also added some unit tests over the authify function.

I have tested it with `npm install -reg https://username:password@somehost/npm/ mymodule` which is my main use case. 

Also bumped the version, not sure if I was meant to do that.