### PR TITLE
Feature: Login (without automated account creation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ Remove a single `dist-tag` from the named package.
 Fetches data from the registry via a GET request, saving it in the cache folder
 with the ETag or the "Last Modified" timestamp.
 
+### client.login(uri, params, cb)
+
+* `uri` {String} Base registry URL.
+* `params` {Object} Object containing per-request properties.
+  * `auth` {Credentials} without email
+* `cb` {Function}
+  * `error` {Error | null}
+  * `data` {Object} the parsed data object
+  * `raw` {String} the json
+  * `res` {Response Object} response from couch
+
+Login to the registry.
+
 ### client.publish(uri, params, cb)
 
 * `uri` {String} The registry URI for the package to publish.

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,0 +1,100 @@
+// NOTE: This is not identical to `npm login` yet. `npm login` uses adduser.js
+
+module.exports = login
+
+var url = require('url')
+var assert = require('assert')
+
+function login (uri, params, cb) {
+  assert(typeof uri === 'string', 'must pass registry URI to login')
+  assert(
+    params && typeof params === 'object',
+    'must pass params to login'
+  )
+  assert(typeof cb === 'function', 'must pass callback to login')
+
+  assert(params.auth && typeof params.auth, 'must pass auth to login')
+  var auth = params.auth
+  assert(typeof auth.username === 'string', 'must include username in auth')
+  assert(typeof auth.password === 'string', 'must include password in auth')
+
+  // normalize registry URL
+  if (uri.slice(-1) !== '/') uri += '/'
+
+  var username = auth.username.trim()
+  var password = auth.password.trim()
+
+  // validation
+  if (!username) return cb(new Error('No username supplied.'))
+  if (!password) return cb(new Error('No password supplied.'))
+
+  var userobj = {
+    _id: 'org.couchdb.user:' + username,
+    name: username,
+    password: password,
+    type: 'user',
+    roles: [],
+    date: new Date().toISOString()
+  }
+
+  var token = this.config.couchToken
+  if (this.couchLogin) this.couchLogin.token = null
+
+  cb = done.call(this, token, cb)
+
+  var logObj = Object.keys(userobj).map(function (k) {
+    if (k === 'password') return [k, 'XXXXX']
+    return [k, userobj[k]]
+  }).reduce(function (s, kv) {
+    s[kv[0]] = kv[1]
+    return s
+  }, {})
+
+  this.log.verbose('login', 'before first PUT', logObj)
+
+  var client = this
+
+  uri = url.resolve(uri, '-/user/org.couchdb.user:' + encodeURIComponent(username))
+  var options = {
+    method: 'PUT',
+    body: userobj
+  }
+  this.request(
+    uri,
+    options,
+    cb
+  )
+
+  function done (token, cb) {
+    return function (error, data, json, response) {
+      if (!error && (!response || response.statusCode === 201)) {
+        return cb(error, data, json, response)
+      }
+
+      // there was some kind of error, reinstate previous auth/token/etc.
+      if (client.couchLogin) {
+        client.couchLogin.token = token
+        if (client.couchLogin.tokenSet) {
+          client.couchLogin.tokenSet(token)
+        }
+      }
+
+      client.log.verbose('login', 'back', [error, data, json])
+      if (!error) {
+        error = new Error(
+          (response && response.statusCode || '') + ' Unable to login'
+        )
+      }
+      var badLogin = response && response.statusCode === 400 || response.statusCode === 401 || response.statusCode === 403
+
+      if (badLogin) {
+        client.log.warn('login', 'Incorrect username or password\n' +
+                                   'You can reset your account by visiting:\n' +
+                                   '\n' +
+                                   '    https://npmjs.org/forgot\n')
+      }
+
+      return cb(error)
+    }
+  }
+}

--- a/test/login.js
+++ b/test/login.js
@@ -1,0 +1,106 @@
+var test = require('tap').test
+
+var server = require('./lib/server.js')
+var common = require('./lib/common.js')
+var client = common.freshClient()
+
+function nop () {}
+
+var URI = 'https://npm.registry:8043/rewrite'
+var USERNAME = 'username'
+var PASSWORD = 'password'
+var AUTH = {
+  auth: {
+    username: USERNAME,
+    password: PASSWORD
+  }
+}
+
+test('login call contract', function (t) {
+  t.throws(function () {
+    client.login(undefined, AUTH, nop)
+  }, 'requires a URI')
+
+  t.throws(function () {
+    client.login([], AUTH, nop)
+  }, 'requires URI to be a string')
+
+  t.throws(function () {
+    client.login(URI, undefined, nop)
+  }, 'requires params object')
+
+  t.throws(function () {
+    client.login(URI, '', nop)
+  }, 'params must be object')
+
+  t.throws(function () {
+    client.login(URI, AUTH, undefined)
+  }, 'requires callback')
+
+  t.throws(function () {
+    client.login(URI, AUTH, 'callback')
+  }, 'callback must be function')
+
+  t.throws(
+    function () {
+      var params = {
+        auth: {
+          password: PASSWORD
+        }
+      }
+      client.login(URI, params, nop)
+    },
+    { name: 'AssertionError', message: 'must include username in auth' },
+    'auth must include username'
+  )
+
+  t.throws(
+    function () {
+      var params = {
+        auth: {
+          username: USERNAME
+        }
+      }
+      client.login(URI, params, nop)
+    },
+    { name: 'AssertionError', message: 'must include password in auth' },
+    'auth must include password'
+  )
+
+  t.test('username missing', function (t) {
+    var params = {
+      auth: {
+        username: '',
+        password: PASSWORD
+      }
+    }
+    client.login(URI, params, function (err) {
+      t.equal(err && err.message, 'No username supplied.', 'username must not be empty')
+      t.end()
+    })
+  })
+
+  t.test('password missing', function (t) {
+    var params = {
+      auth: {
+        username: USERNAME,
+        password: ''
+      }
+    }
+    client.login(URI, params, function (err) {
+      t.equal(
+        err && err.message,
+        'No password supplied.',
+        'password must not be empty'
+      )
+      t.end()
+    })
+  })
+
+  t.end()
+})
+
+test('cleanup', function (t) {
+  server.close()
+  t.end()
+})


### PR DESCRIPTION
Hey :)

I created a new method `.login`, that is similar to `.adduser`, but will not create a new account and also not need an `email` address for the auth. This is related to https://github.com/npm/npm/issues/8337 and would close #135.

I am now noticing though that the `email` is also used for `alwaysAuth`. So probably it would make sense to remove it there as well? Anyway maybe at least this PR can be somewhat helpful.

Love,
Finn
