### PR TITLE
Add browserify support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,6 @@
 
 module.exports = RegClient
 
-var join = require('path').join
-var fs = require('graceful-fs')
-
 var npmlog
 try {
   npmlog = require('npmlog')
@@ -48,32 +45,28 @@ function RegClient (config) {
   delete this.config.log
 
   var client = this
-  fs.readdirSync(join(__dirname, 'lib')).forEach(function (f) {
-    var entry = join(__dirname, 'lib', f)
-
-    // lib/group-name/operation.js -> client.groupName.operation
-    var stat = fs.statSync(entry)
-    if (stat.isDirectory()) {
-      var groupName = f.replace(/-([a-z])/, dashToCamel)
-      fs.readdirSync(entry).forEach(function (f) {
-        if (!f.match(/\.js$/)) return
-
-        if (!client[groupName]) {
-          // keep client.groupName.operation from stomping client.operation
-          client[groupName] = Object.create(client)
-        }
-        var name = f.replace(/\.js$/, '').replace(/-([a-z])/, dashToCamel)
-        client[groupName][name] = require(join(entry, f))
-      })
-      return
-    }
-
-    if (!f.match(/\.js$/)) return
-    var name = f.replace(/\.js$/, '').replace(/-([a-z])/, dashToCamel)
-    client[name] = require(entry)
-  })
-}
-
-function dashToCamel (_, l) {
-  return l.toUpperCase()
+  client.access = require('./lib/access')
+  client.adduser = require('./lib/adduser')
+  client.attempt = require('./lib/attempt')
+  client.authify = require('./lib/authify')
+  client.deprecate = require('./lib/deprecate')
+  client.distTags = Object.create(client)
+  client.distTags.add = require('./lib/dist-tags/add')
+  client.distTags.fetch = require('./lib/dist-tags/fetch')
+  client.distTags.rm = require('./lib/dist-tags/rm')
+  client.distTags.set = require('./lib/dist-tags/set')
+  client.distTags.update = require('./lib/dist-tags/update')
+  client.fetch = require('./lib/fetch')
+  client.get = require('./lib/get')
+  client.initialize = require('./lib/initialize')
+  client.logout = require('./lib/logout')
+  client.ping = require('./lib/ping')
+  client.publish = require('./lib/publish')
+  client.request = require('./lib/request')
+  client.star = require('./lib/star')
+  client.stars = require('./lib/stars')
+  client.tag = require('./lib/tag')
+  client.team = require('./lib/team')
+  client.unpublish = require('./lib/unpublish')
+  client.whoami = require('./lib/whoami')
 }


### PR DESCRIPTION
npm-registry-client depends on synchronous filesystem operations `fs.readdirSync()` and `fs.statSync()`, which are cumbersome to browserify. This PR removes those sync fs API usages to allow for browserification — this is the only change needed, at least to get npm-registry-client to browserify unmodified (npm itself requires additional changes, but this change is simple enough to PR independently).

All tests pass.
