### PR TITLE
remove socket `error` handler after request is done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
   - "0.10"
   - "0.8"
   - iojs
+  - "4"
+  - "6"
+  - stable
 script: "npm test"
 sudo: false
 before_install:

--- a/lib/request.js
+++ b/lib/request.js
@@ -92,7 +92,16 @@ function regRequest (uri, params, cb_) {
 }
 
 function makeRequest (uri, params, cb_) {
-  var cb = once(cb_)
+  var socket
+  var cb = once(function (er, parsed, raw, response) {
+    if (socket) {
+      // The socket might be returned to a pool for re-use, so don’t keep
+      // the 'error' listener from here attached.
+      socket.removeListener('error', cb)
+    }
+
+    return cb_(er, parsed, raw, response)
+  })
 
   var parsed = url.parse(uri)
   var headers = {}
@@ -149,8 +158,13 @@ function makeRequest (uri, params, cb_) {
   var req = request(opts, decodeResponseBody(done))
 
   req.on('error', cb)
+
+  // This should not be necessary, as the HTTP implementation in Node
+  // passes errors occurring on the socket to the request itself. Being overly
+  // cautious comes at a low cost, though.
   req.on('socket', function (s) {
-    s.on('error', cb)
+    socket = s
+    socket.on('error', cb)
   })
 
   if (params.body && (params.body instanceof Stream)) {

--- a/test/lib/common.js
+++ b/test/lib/common.js
@@ -10,6 +10,14 @@ if (!global.setImmediate || !require('timers').setImmediate) {
   }
 }
 
+// See https://github.com/npm/npm-registry-client/pull/142 for background.
+// Note: `process.on('warning')` only works with Node >= 6.
+process.on('warning', function (warning) {
+  if (/Possible EventEmitter memory leak detected/.test(warning.message)) {
+    throw new Error('There should not be any EventEmitter memory leaks')
+  }
+})
+
 module.exports = {
   port: server.port,
   registry: REGISTRY,


### PR DESCRIPTION
Hi y’all! :smile: Carrying this over from https://github.com/nodejs/node/issues/8279#issuecomment-242894705:

`npm-registry-client` uses `request`, which in turn uses an HTTP agent for reusing sockets, so the `error` handlers registered in [these lines in `npm-registry-client`](https://github.com/npm/npm-registry-client/blob/9f0cfda9e0be8858d11a410a2f5112c142f705ac/lib/request.js#L152-L154) just pile up and keep being attached over the entire lifetime of the socket:

```js
  req.on('socket', function (s) {
    s.on('error', cb)
  })
```

which leads to the famous `Warning: Possible EventEmitter memory leak detected. 11 error listeners added.` warning.

This patch seeks to fix this by removing the listener from the socket once the callback is invoked, as keeping it around after that would really just be a memory leak (… I can’t believe that warning message is right for once).

(btw, I’m still not sure having `npm-registry-client` attach error listeners on the socket itself is a correct thing to do, but given that it’s been that way since 2012 and this is a kind of high-profile package, I’m reluctant to do actual behavioural changes…)