### PR TITLE
Fix adduser command option

### DIFF
--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -67,7 +67,7 @@ function adduser (uri, params, cb) {
   }
   this.request(
     uri,
-    options,
+    Object.assign({}, options),
     function (error, data, json, response) {
       if (!error || !response || response.statusCode !== 409) {
         return cb(error, data, json, response)


### PR DESCRIPTION
Hi

After this commit https://github.com/npm/npm-registry-client/commit/fc7b81be395bef9ff45d3929b8154b50f0015d21 , `adduser` command does not work in my environment. I'm using [private npm registry](https://github.com/rlidwka/sinopia). Inside `lib/request.js`, it looks checking the value existence of `params.authed` and adding `authed` param to `option` variable. Inside `lib/adduser.js`, it refers same object to send request. So last request gets error because `options` has already `authed` param ([this request](https://github.com/npm/npm-registry-client/blob/fc7b81be395bef9ff45d3929b8154b50f0015d21/lib/adduser.js#L90) fails). I updated to copy this object.