### PR TITLE
feat: add org.{add,set,rm,ls}

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ function RegClient (config) {
   client.get = require('./lib/get')
   client.initialize = require('./lib/initialize')
   client.logout = require('./lib/logout')
+  client.org = require('./lib/org')
   client.ping = require('./lib/ping')
   client.publish = require('./lib/publish')
   client.request = require('./lib/request')

--- a/lib/org.js
+++ b/lib/org.js
@@ -1,0 +1,62 @@
+'use strict'
+
+module.exports = org
+
+var assert = require('assert')
+var url = require('url')
+
+var subcommands = {}
+
+function org (subcommand, uri, params, cb) {
+  orgAssertions(subcommand, uri, params, cb)
+  return subcommands[subcommand].call(this, uri, params, cb)
+}
+
+subcommands.set = subcommands.add = function (uri, params, cb) {
+  return this.request(apiUri(uri, 'org', params.org, 'user'), {
+    method: 'PUT',
+    auth: params.auth,
+    body: JSON.stringify({
+      user: params.user,
+      role: params.role
+    })
+  }, cb)
+}
+
+subcommands.rm = function (uri, params, cb) {
+  return this.request(apiUri(uri, 'org', params.org, 'user'), {
+    method: 'DELETE',
+    auth: params.auth,
+    body: JSON.stringify({
+      user: params.user
+    })
+  }, cb)
+}
+
+subcommands.ls = function (uri, params, cb) {
+  return this.request(apiUri(uri, 'org', params.org, 'user'), {
+    method: 'GET',
+    auth: params.auth
+  }, cb)
+}
+
+function apiUri (registryUri) {
+  var path = Array.prototype.slice.call(arguments, 1)
+    .map(encodeURIComponent)
+    .join('/')
+  return url.resolve(registryUri, '-/' + path)
+}
+
+function orgAssertions (subcommand, uri, params, cb) {
+  assert(subcommand, 'subcommand is required')
+  assert(subcommands.hasOwnProperty(subcommand),
+         'org subcommand must be one of ' + Object.keys(subcommands))
+  assert(typeof uri === 'string', 'registry URI is required')
+  assert(typeof params === 'object', 'params are required')
+  assert(typeof params.auth === 'object', 'auth is required')
+  assert(!cb || typeof cb === 'function', 'callback must be a function')
+  assert(typeof params.org === 'string', 'org name is required')
+  if (subcommand === 'rm' || subcommand === 'add' || subcommand === 'set') {
+    assert(typeof params.user === 'string', 'user is required')
+  }
+}

--- a/test/org.js
+++ b/test/org.js
@@ -1,0 +1,95 @@
+'use strict'
+
+var test = require('tap').test
+
+var server = require('./lib/server.js')
+var common = require('./lib/common.js')
+var client = common.freshClient()
+
+var URI = 'http://localhost:1337'
+var PARAMS = {
+  auth: {
+    token: 'foo'
+  },
+  org: 'myorg',
+  user: 'myuser'
+}
+
+test('org: add user', function (t) {
+  server.expect('PUT', '/-/org/myorg/user', function (req, res) {
+    t.equal(req.method, 'PUT')
+    onJsonReq(req, function (json) {
+      t.same(json, {user: 'myuser'})
+      res.statusCode = 200
+      res.json({result: 'anything'})
+    })
+  })
+
+  client.org('add', URI, PARAMS, function (err, data) {
+    t.same(err, null)
+    t.same(data, {result: 'anything'})
+    t.done()
+  })
+})
+
+test('org: rm user', function (t) {
+  server.expect('DELETE', '/-/org/myorg/user', function (req, res) {
+    t.equal(req.method, 'DELETE')
+    onJsonReq(req, function (json) {
+      t.same(json, {user: 'myuser'})
+      res.statusCode = 200
+      res.json({result: 'anything'})
+    })
+  })
+
+  client.org('rm', URI, PARAMS, function (err, data) {
+    t.same(err, null)
+    t.same(data, {result: 'anything'})
+    t.done()
+  })
+})
+
+test('org: rm user (400)', function (t) {
+  server.expect('DELETE', '/-/org/myorg/user', function (req, res) {
+    t.equal(req.method, 'DELETE')
+    onJsonReq(req, function (json) {
+      t.same(json, {user: 'myuser'})
+      res.statusCode = 400
+      res.json({result: 'anything'})
+    })
+  })
+
+  client.org('rm', URI, PARAMS, function (err, data) {
+    t.ok(err)
+    t.same(data, {result: 'anything'})
+    t.done()
+  })
+})
+
+test('org: ls', function (t) {
+  server.expect('GET', '/-/org/myorg/user', function (req, res) {
+    t.equal(req.method, 'GET')
+    onJsonReq(req, function () {
+      res.statusCode = 200
+      res.json({result: 'anything'})
+    })
+  })
+
+  client.org('ls', URI, PARAMS, function (err, data) {
+    t.same(err, null)
+    t.same(data, {result: 'anything'})
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  server.close()
+  t.end()
+})
+
+function onJsonReq (req, cb) {
+  var buffer = ''
+  req.setEncoding('utf8')
+  req.on('data', function (data) { buffer += data })
+  req.on('end', function () { cb(buffer ? JSON.parse(buffer) : undefined) })
+}

--- a/test/org.js
+++ b/test/org.js
@@ -71,13 +71,13 @@ test('org: ls', function (t) {
     t.equal(req.method, 'GET')
     onJsonReq(req, function () {
       res.statusCode = 200
-      res.json({result: 'anything'})
+      res.json({username: 'role', username2: 'admin'})
     })
   })
 
   client.org('ls', URI, PARAMS, function (err, data) {
     t.same(err, null)
-    t.same(data, {result: 'anything'})
+    t.same(data, {username: 'role', username2: 'admin'})
     t.done()
   })
 })


### PR DESCRIPTION
(Patterned after `{lib,test}/team.js`.)

This adds backing support for the following commands:

```bash
$ npm org add orgname username [role]
$ npm org set orgname username [role]
$ npm org rm orgname username
$ npm org ls
```