### PR TITLE
Fix for increased readability of "404 'artifactory' is not in the npm registry"

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -279,7 +279,7 @@ function requestDone (method, where, cb) {
       var name
       if (!w.match(/^-/)) {
         w = w.split('/')
-        name = decodeURIComponent(w[w.indexOf('_rewrite') + 1])
+        name = decodeURIComponent(w[w.length - 1])
       }
 
       if (!parsed.error) {


### PR DESCRIPTION
Fix: change decodeURIComponent call in request.js to print end of string (past last /) as package name for readability when using default or custom repositories.