### PR TITLE
feat(integrity): add integrity field to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "request": "^2.74.0",
     "retry": "^0.10.0",
     "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-    "slide": "^1.1.3"
+    "slide": "^1.1.3",
+    "ssri": "^4.1.2"
   },
   "devDependencies": {
     "negotiator": "^0.6.1",

--- a/test/publish.js
+++ b/test/publish.js
@@ -1,6 +1,9 @@
-var test = require('tap').test
+'use strict'
+
 var crypto = require('crypto')
+var test = require('tap').test
 var fs = require('fs')
+var ssri = require('ssri')
 
 var server = require('./lib/server.js')
 var common = require('./lib/common.js')
@@ -187,7 +190,19 @@ test('publish', function (t) {
       t.same(att.data, pd.toString('base64'))
 
       var hash = crypto.createHash('sha1').update(pd).digest('hex')
-      t.equal(o.versions[METADATA.version].dist.shasum, hash)
+      var integrity = ssri.fromData(pd, {
+        algorithms: ['sha512']
+      })
+      t.equal(
+        o.versions[METADATA.version].dist.shasum,
+        hash,
+        'shasum is the same as generated originally by crypto module'
+      )
+      t.equal(
+        o.versions[METADATA.version].dist.integrity,
+        integrity.toString(),
+        'integrity field is a valid SRI string'
+      )
 
       res.statusCode = 201
       res.json({ created: true })


### PR DESCRIPTION
This adds a `dist.integrity` field to published metadata, alongside the original `dist.shasum`. I've already done a test publish over at npm.im/@zkat/integrity-test which you can check out yourself, and `pacote` handles it just fine!

We can even shove this into `npm@4` and it'll start getting used right away :D