### PR TITLE
Use the last part of URL path if _rewrite does not exist

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -280,10 +280,10 @@ function requestDone (method, where, cb) {
       if (!w.match(/^-/)) {
         w = w.split('/')
         var index = w.indexOf('_rewrite')
-        if(index === -1) {
-            index = w.length - 1
+        if (index === -1) {
+          index = w.length - 1
         } else {
-            index++
+          index++
         }
         name = decodeURIComponent(w[index])
       }

--- a/lib/request.js
+++ b/lib/request.js
@@ -279,7 +279,13 @@ function requestDone (method, where, cb) {
       var name
       if (!w.match(/^-/)) {
         w = w.split('/')
-        name = decodeURIComponent(w[w.indexOf('_rewrite') + 1])
+        var index = w.indexOf('_rewrite')
+        if(index === -1) {
+            index = w.length - 1
+        } else {
+            index++
+        }
+        name = decodeURIComponent(w[index])
       }
 
       if (!parsed.error) {


### PR DESCRIPTION
If npm is configured to point to a custom registry whose registry path has multiple components to it (e.g. Artifactory: `http://artifactory-hostname/artifactory/api/npm/`) and you try to install a package that does not exist (e.g. `some-nonexistent-package-name`), it will use the first component in the path as the package name in the 404 error. 

```
npm ERR! code E404
npm ERR! 404 Not Found: artifactory
npm ERR! 404 
npm ERR! 404  'artifactory' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
```

Instead, it should read:

```
npm ERR! code E404
npm ERR! 404 Not Found: some-package-name
npm ERR! 404 
npm ERR! 404  'some-package-name' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
```

In line [282](https://github.com/npm/npm-registry-client/blob/master/lib/request.js#L281) `request.js` tries to use the part of the path that follows `_rewrite` as the name of the package that failed the installation. However, if `_rewrite` does not exist, it will default to using the first part, which for registries with multi-part paths, will not be correct, since it is the *last* part of the path that is the package name. 

This pr builds off of [#156](https://github.com/npm/npm-registry-client/pull/156) by still permitting the search for `_rewrite` and defaulting to the *last* part of the URL path.