### PR TITLE
remove node 0.10 workaround

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -35,10 +35,7 @@ function fetch (uri, params, cb) {
         var er
         var statusCode = res && res.statusCode
         if (statusCode === 200) {
-          // Work around bug in node v0.10.0 where the CryptoStream
-          // gets stuck and never starts reading again.
           res.resume()
-          if (process.version === 'v0.10.0') unstick(res)
 
           req.once('error', function (er) {
             res.emit('error', er)


### PR DESCRIPTION
0.10 is not supported since a while. remove workaround for less
code / easier maintaining.