### PR TITLE
CI reporting for npm use within GoCD pipelines.

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -14,7 +14,8 @@ function initialize (uri, method, accept, headers) {
   if (this.config.isFromCI == null) {
     this.config.isFromCI = Boolean(
       process.env['CI'] === 'true' || process.env['TDDIUM'] ||
-      process.env['JENKINS_URL'] || process.env['bamboo.buildKey'])
+      process.env['JENKINS_URL'] || process.env['bamboo.buildKey'] ||
+      process.env['GO_PIPELINE_NAME'])
   }
 
   var opts = {


### PR DESCRIPTION
Added an env. var. check to determine if npm is being used from a GoCD (https://www.gocd.org/) pipeline. 