### PR TITLE
Update ssri to non-vulnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "retry": "^0.10.0",
     "semver": "2 >=2.2.1 || 3.x || 4 || 5",
     "slide": "^1.1.3",
-    "ssri": "^4.1.2"
+    "ssri": "^5.2.4"
   },
   "devDependencies": {
     "negotiator": "^0.6.1",


### PR DESCRIPTION
Fixes https://nodesecurity.io/advisories/565

Before:

```
> nsp check

(+) 1 vulnerability found
┌────────────┬────────────────────────────────────────────────────────────────────┐
│            │ ReDoS in ssri                                                      │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Name       │ ssri                                                               │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ CVSS       │ 5.3 (Medium)                                                       │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Installed  │ 4.1.6                                                              │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Vulnerable │ <=5.2.1                                                            │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Patched    │ >=5.2.2                                                            │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ Path       │ npm-registry-client@8.5.0 > ssri@4.1.6                             │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ More Info  │ https://nodesecurity.io/advisories/565                             │
└────────────┴────────────────────────────────────────────────────────────────────┘
```

After:

```
> nsp check

(+) No known vulnerabilities found
```
