### PR TITLE
docs: update retry config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ any):
 * `ssl.key` {String} Private key (PEM encoded) for client certificate.
 * `ssl.strict` {Boolean} Whether or not to be strict with SSL certificates.
   Default = `true`
-* `retry.count` {Number} Number of times to retry on GET failures. Default = 2.
+* `retry.retries` {Number} Number of times to retry on GET failures. Default = 2.
 * `retry.factor` {Number} `factor` setting for `node-retry`. Default = 10.
 * `retry.minTimeout` {Number} `minTimeout` setting for `node-retry`.
   Default = 10000 (10 seconds)


### PR DESCRIPTION
Update the documentation to use the correct parameter [`retries`](https://github.com/npm/npm-registry-client/blob/latest/index.js#L35) for the number of retries (instead of `count`).

closes #162